### PR TITLE
Update README with release information.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 # The Checked C clang repo
 
-This repo contains a version of the LLVM/Clang toolchain that is being modified
-to support the Secure Software Development Project (SSDP) fork of Checked C. Checked C extends
-C with checking to detect or prevent common programming errors such as out-of-bounds memory accesses.
-The SSDP fork of the Checked
-C specification is available at the
-[SSDP Checked C repo](https://github.com/secure-sw-dev/checkedc).
+This repo contains a version of the LLVM/Clang toolchain that has been modified to support Checked C. 
+Checked C extends C with checking to detect or prevent common programming errors such as out-of-bounds memory accesses.
+The Checked C specification is available at the
+[Checked C repo release page](https://github.com/checkedc/checkedc/releases).
 
+<!--- 
 ## Announcements
 
 ### Source code update
@@ -16,17 +15,21 @@ specifically [this](https://github.com/llvm/llvm-project/commit/2e10b7a39b930ef8
 
 On Feb 18, 2020 we updated the checkedc-clang sources to upstream release_90,
 specifically [this](https://github.com/llvm/llvm-project/commit/c89a3d78f43d81b9cff7b9248772ddf14d21b749) commit.
+--->
 
 ## Trying out Checked C
 
-Programmers are welcome to use Checked C as it is being implemented.  You will
-have to build your own copy of the compiler. For
-directions on how to do this, see the [Checked C clang
-wiki](https://github.com/secure-sw-dev/checkedc-llvm-project/wiki). The compiler user
-manual is
-[here](https://github.com/secure-sw-dev/checkedc-llvm-project/wiki/Checked-C-clang-user-manual).
+You can install the Checked C compiler and the 3C tool
+from the [Checked C LLVM Project release page] (https://github.com/checkedc/checkedc-llvm-project/releases).  
+There are versions available for Ubuntu 22.04, Windows 10/11, and MacOS. 
+The compiler user
+manual is [here](https://github.com/checkedc/checkedc-llvm-project/wiki/Checked-C-clang-user-manual).
 For more information on Checked C and pointers to example code, see our
-[Wiki](https://github.com/secure-sw-dev/checkedc/wiki).
+[Wiki](https://github.com/checkedc/checkedc/wiki).
+
+If you want to build your own copy of the compiler, see the directions
+Checked C clang wiki](https://github.com/checkedc/checkedc-llvm-project/wiki). 
+
 
 You can use `clangd` built from this repository to get similar IDE support for
 editing Checked C code as upstream `clangd` provides for C code. For example,
@@ -48,8 +51,8 @@ conversion of C code to Checked C. Quick documentation links:
 
 ## More information
 
-For more information on the SSDP Checked C clang compiler, see the [SSDP LLVM Project
-wiki](https://github.com/secure-sw-dev/checkedc-llvm-project/wiki).
+For more information on the Checked C clang compiler, see the [SSDP LLVM Project
+wiki](https://github.com/checkedc/checkedc-llvm-project/wiki).
 
 ## Build Status
 
@@ -59,14 +62,14 @@ Automated builds are not currently available.
 
 We welcome contributions to the Checked C project. To get involved in the
 project, see [Contributing to Checked
-C](https://github.com/secure-sw-dev/checkedc/blob/main/CONTRIBUTING.md).
+C](https://github.com/checkedc/checkedc/blob/main/CONTRIBUTING.md).
 
 For code contributions, we follow the standard [Github
 workflow](https://guides.github.com/introduction/flow/). See [Contributing to
-Checked C](https://github.com/secure-sw-dev/checkedc/blob/main/CONTRIBUTING.md)
+Checked C](https://github.com/checkedc/checkedc/blob/main/CONTRIBUTING.md)
 for more detail.
 
 ## Code of conduct
 
 This project has adopted a
-[code of conduct](https://github.com/secure-sw-dev/checkedc/blob/main/CODE_OF_CONDUCT.md).
+[code of conduct](https://github.com/checkedc/checkedc/blob/main/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
- Add information on how to find pre-built versions of the compiler.
- Fix links that pointed to the secure-sw-dev project on GitHub.  We renamed the project to checkedc.