### PR TITLE
Enable two tests that actually work on Apple ARM64 Macs.

### DIFF
--- a/clang/test/Driver/openmp-offload-gpu.c
+++ b/clang/test/Driver/openmp-offload-gpu.c
@@ -3,7 +3,6 @@
 ///
 
 // https://PR46644
-// XFAIL: arm64-apple
 
 // REQUIRES: clang-driver
 // REQUIRES: x86-registered-target

--- a/clang/test/Driver/openmp-offload.c
+++ b/clang/test/Driver/openmp-offload.c
@@ -3,7 +3,6 @@
 ///
 
 // https://PR46644
-// XFAIL: arm64-apple
 
 // REQUIRES: clang-driver
 // REQUIRES: x86-registered-target


### PR DESCRIPTION
There are two tests marked as "expected fail" for Apple ARM64 that actually work.  Enable them.
