### PR TITLE
Fix crash when processing GCC statement expression

### DIFF
--- a/clang/lib/AST/CanonBounds.cpp
+++ b/clang/lib/AST/CanonBounds.cpp
@@ -440,7 +440,6 @@ Result Lexicographic::CompareExpr(const Expr *Arg1, const Expr *Arg2) const {
 
      // GNU Extensions.
      case Expr::AddrLabelExprClass: break;
-     case Expr::StmtExprClass: break;
      case Expr::ChooseExprClass: break;
      case Expr::GNUNullExprClass: break;
 
@@ -472,6 +471,7 @@ Result Lexicographic::CompareExpr(const Expr *Arg1, const Expr *Arg2) const {
      // of Lexicographic. These expressions are compared by their addresses.
      // This comparison will be deterministic for one compiler run, but is
      // not guaranteed to be deterministic across compiler runs.
+     case Expr::StmtExprClass:
      case Expr::ExtVectorElementExprClass:
      case Expr::InitListExprClass:
      case Expr::ImplicitValueInitExprClass: return CompareAddress(E1, E2);

--- a/clang/lib/Sema/SemaBounds.cpp
+++ b/clang/lib/Sema/SemaBounds.cpp
@@ -5264,11 +5264,9 @@ namespace {
       if (!Val)
         return;
 
-      // StmtExprs should not be included in SameValue.  When StmtExprs are
-      // lexicographically compared, there is an assertion failure since
-      // the children of StmtExprs are Stmts and not Exprs, so StmtExprs
-      // should not be included in any sets that involve comparisons,
-      // such as CheckingState.SameValue or CheckingState.EquivExprs.
+      // StmtExprs should not be included in SameValue. Lexicographic
+      // comparison for StmtExprs is not implemented.  It just compares
+      // compares pointer values.
       if (isa<StmtExpr>(Val))
         return;
 

--- a/clang/test/CheckedC/regression-cases/bug_1220_stmt_expr.c
+++ b/clang/test/CheckedC/regression-cases/bug_1220_stmt_expr.c
@@ -1,0 +1,13 @@
+//
+// These is a regression test case for
+// https://github.com/checkedc/checkedc-llvm-project/issues/1220
+//
+// This test checks that the compiler does not crash when it sees the GCC
+// statement expression language extension.
+
+// RUN: %clang -cc1 -verify -fcheckedc-extension %s
+
+void f(void) {
+  int *a = ({ 0; });  // expected-warning {{ integer to pointer conversion }}
+}
+


### PR DESCRIPTION
This fixes issue #1220, a crash when processing a GCC statement expression.   The problem was that lexicographic comparison of expressions assumed that all children of expressions are expressions also.  This is no true for the GCC statement expression extension, which wraps a statement in an expression.
