### PR TITLE
    Fix compiler assert involving a bound-safe interface with a typedef'ed type.

### DIFF
--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -9515,7 +9515,7 @@ Sema::CheckAssignmentConstraints(QualType LHSType, ExprResult &RHS,
         RHSType->isUncheckedArrayType())) {
     QualType RHSInteropType = GetCheckedCRValueInteropType(RHS);
     if (!RHSInteropType.isNull())
-      RHSType = RHSInteropType;
+      RHSType = Context.getCanonicalType(RHSInteropType).getUnqualifiedType();
   }
 
   // Common case: no conversion required.

--- a/clang/test/CheckedC/regression-cases/bug_1200_canon_types.c
+++ b/clang/test/CheckedC/regression-cases/bug_1200_canon_types.c
@@ -1,12 +1,22 @@
-typedef char CHAR16;
+// This is a regression test case for
+//  https://github.com/checkedc/checkedc-llvm-project/issues/1200
+//
+// This test checks conversion of a pointer-typed variable with a
+// bounds-safe interface to an unchecked pointer type, wehere the
+// bound-safe interface type uses a typedef'ed type.
+//
+// RUN: %clang -cc1 -verify -fcheckedc-extension %s
+// expected-no-diagnostics
+
+typedef char CHAR;
 
 int
-FindAccessVariable (_Nt_array_ptr<CHAR16> VariableName) {
+FindAccessVariable (_Nt_array_ptr<char> VariableName) {
   return -1;
 }
 
 int
 mineVariableServiceGetVariable (
-CHAR16 *VariableName : itype(_Nt_array_ptr<CHAR16>)) {
+char  *VariableName : itype(_Nt_array_ptr<CHAR>)) {
 return FindAccessVariable (VariableName);
 }

--- a/clang/test/CheckedC/regression-cases/bug_1200_canon_types.c
+++ b/clang/test/CheckedC/regression-cases/bug_1200_canon_types.c
@@ -1,0 +1,12 @@
+typedef char CHAR16;
+
+int
+FindAccessVariable (_Nt_array_ptr<CHAR16> VariableName) {
+  return -1;
+}
+
+int
+mineVariableServiceGetVariable (
+CHAR16 *VariableName : itype(_Nt_array_ptr<CHAR16>)) {
+return FindAccessVariable (VariableName);
+}


### PR DESCRIPTION

This fixes issue #1200.  The conversion of a pointer-typed variable with a bounds-safe interface to an unchecked pointer type was failing when the bound-safe interface type used a typedef'ed type. There was an assertion that a type had not been canonicalized. The fix is to use the canonicalized version of the bounds-safe interface type in the conversion code.  This change includes a test case for the failure.