### PR TITLE
Adding lsp support for 3c and adding conflict resolver for graphs used by 3c

### DIFF
--- a/clang-tools-extra/clangd/3CCommands.cpp
+++ b/clang-tools-extra/clangd/3CCommands.cpp
@@ -19,7 +19,7 @@ namespace clangd {
 
 static bool GetPtrIDFromDiagMessage(const Diagnostic &DiagMsg,
                                     unsigned long &PtrId) {
-  if (DiagMsg.source.rfind(_3CSOURCE, 0) == 0) {
+  if (DiagMsg.source==_3CSOURCE) {
     PtrId = atoi(DiagMsg.code.c_str());
     return true;
   }
@@ -35,13 +35,13 @@ void AsCCCommands(const Diagnostic &D, std::vector<Command> &OutCommands) {
     AllPtrsCmd._3CFix = PtrFix;
     Command SinglePtrCmd = AllPtrsCmd;
 
-    AllPtrsCmd.command = ExecuteCommandParams::_3C_APPLY_FOR_ALL.str();
+    AllPtrsCmd.command = std::string(Command::_3C_APPLY_FOR_ALL);
     AllPtrsCmd.title = "Make this pointer non-WILD and apply the "
                        "same observation to all the pointers.";
 
     OutCommands.push_back(AllPtrsCmd);
 
-    SinglePtrCmd.command = Command::_3C_APPLY_ONLY_FOR_THIS.str();
+    SinglePtrCmd.command = std::string(Command::_3C_APPLY_ONLY_FOR_THIS);
     SinglePtrCmd.title = "Make ONLY this pointer non-WILD.";
 
     OutCommands.push_back(SinglePtrCmd);
@@ -49,22 +49,23 @@ void AsCCCommands(const Diagnostic &D, std::vector<Command> &OutCommands) {
 }
 
 bool Is3CCommand(const ExecuteCommandParams &Params) {
-  return (Params.command.rfind(Command::_3C_APPLY_ONLY_FOR_THIS.str(), 0) == 0) ||
-         (Params.command.rfind(Command::_3C_APPLY_FOR_ALL.str(), 0) == 0);
+  return (Params.command==Command::_3C_APPLY_ONLY_FOR_THIS||
+         Params.command==Command::_3C_APPLY_FOR_ALL);
 }
 
 bool ExecuteCCCommand(const ExecuteCommandParams &Params,
                       std::string &ReplyMessage,
                       _3CInterface &CcInterface) {
   ReplyMessage = "Checked C Pointer Modified.";
-  if (Params.command.rfind(Command::_3C_APPLY_ONLY_FOR_THIS.str(), 0) == 0) {
+  if (Params.command==Command::_3C_APPLY_ONLY_FOR_THIS) {
     int PtrId = Params._3CFix->ptrID;
-    /*CcInterface.makeSinglePtrNonWild(PtrId);*/
+    CcInterface.makeSinglePtrNonWild(PtrId);
     log("Single Pointer Wild.");
     return true;
   }
-  if (Params.command.rfind(Command::_3C_APPLY_FOR_ALL.str(), 0) == 0) {
+  if (Params.command==Command::_3C_APPLY_FOR_ALL){
     int PtrId = Params._3CFix->ptrID;
+    /*CcInterface.invalidateWildReasonGlobally(PtrId);*/
     log("Global Pointer Wild.");
     return true;
   }

--- a/clang-tools-extra/clangd/3CCommands.cpp
+++ b/clang-tools-extra/clangd/3CCommands.cpp
@@ -49,21 +49,21 @@ void AsCCCommands(const Diagnostic &D, std::vector<Command> &OutCommands) {
 }
 
 bool Is3CCommand(const ExecuteCommandParams &Params) {
-  return (Params.command==Command::_3C_APPLY_ONLY_FOR_THIS||
-         Params.command==Command::_3C_APPLY_FOR_ALL);
+  return (Params.command == Command::_3C_APPLY_ONLY_FOR_THIS ||
+         Params.command == Command::_3C_APPLY_FOR_ALL);
 }
 
 bool ExecuteCCCommand(const ExecuteCommandParams &Params,
                       std::string &ReplyMessage,
                       _3CInterface &CcInterface) {
   ReplyMessage = "Checked C Pointer Modified.";
-  if (Params.command==Command::_3C_APPLY_ONLY_FOR_THIS) {
+  if (Params.command == Command::_3C_APPLY_ONLY_FOR_THIS) {
     int PtrId = Params._3CFix->ptrID;
     CcInterface.makeSinglePtrNonWild(PtrId);
     log("Single Pointer Wild.");
     return true;
   }
-  if (Params.command==Command::_3C_APPLY_FOR_ALL){
+  if (Params.command == Command::_3C_APPLY_FOR_ALL){
     int PtrId = Params._3CFix->ptrID;
     CcInterface.invalidateWildReasonGlobally(PtrId);
     log("Global Pointer Wild.");

--- a/clang-tools-extra/clangd/3CCommands.cpp
+++ b/clang-tools-extra/clangd/3CCommands.cpp
@@ -1,0 +1,75 @@
+//=--3CCommands.cpp-----------------------------------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// Implementation of 3C command helper methods.
+//===----------------------------------------------------------------------===//
+
+#ifdef LSP3C
+#include "3CCommands.h"
+#include "support/Logger.h"
+
+namespace clang {
+namespace clangd {
+
+#define _3CSOURCE "3C_RealWild"
+
+static bool GetPtrIDFromDiagMessage(const Diagnostic &DiagMsg,
+                                    unsigned long &PtrId) {
+  if (DiagMsg.source.rfind(_3CSOURCE, 0) == 0) {
+    PtrId = atoi(DiagMsg.code.c_str());
+    return true;
+  }
+  return false;
+}
+
+void AsCCCommands(const Diagnostic &D, std::vector<Command> &OutCommands) {
+  unsigned long PtrId;
+  if (GetPtrIDFromDiagMessage(D, PtrId)) {
+    Command AllPtrsCmd;
+    _3CManualFix PtrFix;
+    PtrFix.ptrID = PtrId;
+    AllPtrsCmd._3CFix = PtrFix;
+    Command SinglePtrCmd = AllPtrsCmd;
+
+    AllPtrsCmd.command = ExecuteCommandParams::_3C_APPLY_FOR_ALL.str();
+    AllPtrsCmd.title = "Make this pointer non-WILD and apply the "
+                       "same observation to all the pointers.";
+
+    OutCommands.push_back(AllPtrsCmd);
+
+    SinglePtrCmd.command = Command::_3C_APPLY_ONLY_FOR_THIS.str();
+    SinglePtrCmd.title = "Make ONLY this pointer non-WILD.";
+
+    OutCommands.push_back(SinglePtrCmd);
+  }
+}
+
+bool Is3CCommand(const ExecuteCommandParams &Params) {
+  return (Params.command.rfind(Command::_3C_APPLY_ONLY_FOR_THIS.str(), 0) == 0) ||
+         (Params.command.rfind(Command::_3C_APPLY_FOR_ALL.str(), 0) == 0);
+}
+
+bool ExecuteCCCommand(const ExecuteCommandParams &Params,
+                      std::string &ReplyMessage,
+                      _3CInterface &CcInterface) {
+  ReplyMessage = "Checked C Pointer Modified.";
+  if (Params.command.rfind(Command::_3C_APPLY_ONLY_FOR_THIS.str(), 0) == 0) {
+    int PtrId = Params._3CFix->ptrID;
+    /*CcInterface.makeSinglePtrNonWild(PtrId);*/
+    log("Single Pointer Wild.");
+    return true;
+  }
+  if (Params.command.rfind(Command::_3C_APPLY_FOR_ALL.str(), 0) == 0) {
+    int PtrId = Params._3CFix->ptrID;
+    log("Global Pointer Wild.");
+    return true;
+  }
+  return false;
+}
+}
+}
+#endif

--- a/clang-tools-extra/clangd/3CCommands.cpp
+++ b/clang-tools-extra/clangd/3CCommands.cpp
@@ -65,7 +65,7 @@ bool ExecuteCCCommand(const ExecuteCommandParams &Params,
   }
   if (Params.command==Command::_3C_APPLY_FOR_ALL){
     int PtrId = Params._3CFix->ptrID;
-    /*CcInterface.invalidateWildReasonGlobally(PtrId);*/
+    CcInterface.invalidateWildReasonGlobally(PtrId);
     log("Global Pointer Wild.");
     return true;
   }

--- a/clang-tools-extra/clangd/3CCommands.h
+++ b/clang-tools-extra/clangd/3CCommands.h
@@ -1,0 +1,33 @@
+//=--3CCommands.h-------------------------------------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// Helper methods used to handle 3C commands.
+//===----------------------------------------------------------------------===//
+
+#ifdef LSP3C
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANGD_3CCOMMANDS_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANGD_3CCOMMANDS_H
+
+#include "Protocol.h"
+#include "clang/3C/3C.h"
+
+namespace clang {
+namespace clangd {
+// Convert the provided Diagnostic into Commands
+void AsCCCommands(const Diagnostic &D, std::vector<Command> &OutCommands);
+// Check if the execute command request from the client is a 3C command.
+bool Is3CCommand(const ExecuteCommandParams &Params);
+
+// Interpret the provided execute command request as 3C command
+// and execute them.
+bool ExecuteCCCommand(const ExecuteCommandParams &Params,
+                      std::string &ReplyMessage,
+                      _3CInterface &CcInterface);
+}
+}
+#endif //LLVM_CLANG_TOOLS_EXTRA_CLANGD_3CCOMMANDS_H
+#endif

--- a/clang-tools-extra/clangd/3CDiagnostics.cpp
+++ b/clang-tools-extra/clangd/3CDiagnostics.cpp
@@ -1,0 +1,79 @@
+//===--- 3CDiagnostics.cpp - 3C Diagnostics Functions -----------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifdef LSP3C
+#include "3CDiagnostics.h"
+#define DEF_PTR_SIZE 4
+
+namespace clang {
+namespace clangd {
+
+void _3CDiagnostics::ClearAllDiags() {
+  std::lock_guard<std::mutex> Lock(DiagMutex);
+}
+
+static bool IsValidSourceFile(ConstraintsInfo &CCRes, std::string &FilePath) {
+  return CCRes.ValidSourceFiles.find(FilePath) != CCRes.ValidSourceFiles.end();
+}
+
+bool _3CDiagnostics::PopulateDiagsFromConstraintsInfo(ConstraintsInfo &Line) {
+  std::lock_guard<std::mutex> Lock(DiagMutex);
+  std::set<ConstraintKey> ProcessedCKeys;
+  ProcessedCKeys.clear();
+  auto GetLocRange = [](uint32_t Line, uint32_t ColNoS,
+                        uint32_t ColNoE) -> Range {
+    Range nRange;
+    Line--;
+    nRange.start.line = Line;
+    nRange.end.line = Line;
+    nRange.start.character = ColNoS;
+    if (ColNoE > 0) {
+      nRange.end.character = ColNoE;
+    } else {
+      nRange.end.character = ColNoS + DEF_PTR_SIZE;
+    }
+    return nRange;
+  };
+
+  for (auto &WReason : Line.RootWildAtomsWithReason) {
+    if (Line.AtomSourceMap.find(WReason.first) != Line.AtomSourceMap.end()) {
+      auto PsInfo = Line.AtomSourceMap[WReason.first];
+      std::string FilePath = PsInfo.getFileName();
+      // If this is not a file in a project? Then ignore.
+      if (!IsValidSourceFile(Line, FilePath))
+        continue;
+
+      ProcessedCKeys.insert(WReason.first);
+
+      Diag NewDiag;
+      NewDiag.Range = GetLocRange(PsInfo.getLineNo(), PsInfo.getColSNo(),
+                                  PsInfo.getColENo());
+      NewDiag.Source = Diag::Main3C;
+      NewDiag.Severity = DiagnosticsEngine::Level::Error;
+      NewDiag.code = std::to_string(WReason.first);
+      NewDiag.Message =
+          "Pointer is wild because of:" + WReason.second.getReason();
+
+      // Create notes for the information about root cause.
+      PersistentSourceLoc SL = WReason.second.getLocation();
+      if (SL.valid()) {
+        Note DiagNote;
+        DiagNote.AbsFile = SL.getFileName();
+        DiagNote.Range =
+            GetLocRange(SL.getLineNo(), SL.getColSNo(), SL.getColENo());
+        DiagNote.Message = "Go here to know the root cause for this.";
+        NewDiag.Notes.push_back(DiagNote);
+      }
+      AllFileDiagnostics[FilePath].push_back(NewDiag);
+    }
+  }
+  return true;
+}
+}
+}
+#endif

--- a/clang-tools-extra/clangd/3CDiagnostics.cpp
+++ b/clang-tools-extra/clangd/3CDiagnostics.cpp
@@ -8,6 +8,7 @@
 
 #ifdef LSP3C
 #include "3CDiagnostics.h"
+#include "support/Logger.h"
 #define DEF_PTR_SIZE 4
 
 namespace clang {
@@ -55,9 +56,8 @@ bool _3CDiagnostics::PopulateDiagsFromConstraintsInfo(ConstraintsInfo &Line) {
                                   PsInfo.getColENo());
       NewDiag.Source = Diag::Main3C;
       NewDiag.Severity = DiagnosticsEngine::Level::Error;
-      NewDiag.code = std::to_string(WReason.first);
       NewDiag.Message =
-          "Pointer is wild because of:" + WReason.second.getReason();
+          "Pointer is wild because of :" + WReason.second.getReason();
 
       // Create notes for the information about root cause.
       PersistentSourceLoc SL = WReason.second.getLocation();
@@ -70,6 +70,8 @@ bool _3CDiagnostics::PopulateDiagsFromConstraintsInfo(ConstraintsInfo &Line) {
         NewDiag.Notes.push_back(DiagNote);
       }
       AllFileDiagnostics[FilePath].push_back(NewDiag);
+      log(AllFileDiagnostics[FilePath].data()->Message.data());
+
     }
   }
   return true;

--- a/clang-tools-extra/clangd/3CDiagnostics.h
+++ b/clang-tools-extra/clangd/3CDiagnostics.h
@@ -1,0 +1,45 @@
+//=--3CDiagnostics.h----------------------------------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// Class that handles 3C Diagnostic messages.
+//===----------------------------------------------------------------------===//
+
+#ifdef LSP3C
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANGD_3CDIAGNOSTICS_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANGD_3CDIAGNOSTICS_H
+
+#include <set>
+#include "Diagnostics.h"
+#include "clang/3C/3C.h"
+
+namespace clang {
+namespace clangd {
+
+// Class that represents diagnostics messages specific to 3C.
+class _3CDiagnostics {
+public:
+  std::mutex DiagMutex;
+
+  // GUARDED by DiagMutex
+  // Populate diagnostics from the given disjoint set.
+  bool PopulateDiagsFromConstraintsInfo(ConstraintsInfo &Line);
+  // GUARDED by DiagMutex
+  // Clear diagnostics of all files.
+  void ClearAllDiags();
+  std::map<std::string, std::vector<Diag>> &GetAllFilesDiagnostics() {
+    return AllFileDiagnostics;
+  }
+private:
+  // Diagnostics of all files.
+  std::map<std::string, std::vector<Diag>> AllFileDiagnostics;
+
+
+};
+}
+}
+#endif //LLVM_CLANG_TOOLS_EXTRA_CLANGD_
+#endif

--- a/clang-tools-extra/clangd/3CDiagnostics.h
+++ b/clang-tools-extra/clangd/3CDiagnostics.h
@@ -33,6 +33,9 @@ public:
   std::map<std::string, std::vector<Diag>> &GetAllFilesDiagnostics() {
     return AllFileDiagnostics;
   }
+  std::vector<Diag> &Get3CDiagsForThisFile(std::string FileName){
+    return AllFileDiagnostics[FileName];
+  }
 private:
   // Diagnostics of all files.
   std::map<std::string, std::vector<Diag>> AllFileDiagnostics;

--- a/clang-tools-extra/clangd/CMakeLists.txt
+++ b/clang-tools-extra/clangd/CMakeLists.txt
@@ -135,6 +135,7 @@ clang_target_link_libraries(clangDaemon
   clangAST
   clangASTMatchers
   clangBasic
+  clang3C
   clangDriver
   clangFormat
   clangFrontend

--- a/clang-tools-extra/clangd/CMakeLists.txt
+++ b/clang-tools-extra/clangd/CMakeLists.txt
@@ -135,7 +135,6 @@ clang_target_link_libraries(clangDaemon
   clangAST
   clangASTMatchers
   clangBasic
-  clang3C
   clangDriver
   clangFormat
   clangFrontend
@@ -159,6 +158,121 @@ target_link_libraries(clangDaemon
   clangdSupport
   )
 
+add_clang_library(3cClangDaemon
+        AST.cpp
+        ASTSignals.cpp
+        ClangdLSPServer.cpp
+        ClangdServer.cpp
+        CodeComplete.cpp
+        CodeCompletionStrings.cpp
+        CollectMacros.cpp
+        CompileCommands.cpp
+        Compiler.cpp
+        Config.cpp
+        ConfigCompile.cpp
+        ConfigProvider.cpp
+        ConfigYAML.cpp
+        Diagnostics.cpp
+        DraftStore.cpp
+        DumpAST.cpp
+        ExpectedTypes.cpp
+        FindSymbols.cpp
+        FindTarget.cpp
+        FileDistance.cpp
+        Format.cpp
+        FS.cpp
+        FuzzyMatch.cpp
+        GlobalCompilationDatabase.cpp
+        Headers.cpp
+        HeaderSourceSwitch.cpp
+        Hover.cpp
+        IncludeFixer.cpp
+        JSONTransport.cpp
+        PathMapping.cpp
+        Protocol.cpp
+        Quality.cpp
+        ParsedAST.cpp
+        Preamble.cpp
+        RIFF.cpp
+        Selection.cpp
+        SemanticHighlighting.cpp
+        SemanticSelection.cpp
+        SourceCode.cpp
+        QueryDriverDatabase.cpp
+        TidyProvider.cpp
+        TUScheduler.cpp
+        URI.cpp
+        XRefs.cpp
+        ${CMAKE_CURRENT_BINARY_DIR}/CompletionModel.cpp
+
+        index/Background.cpp
+        index/BackgroundIndexLoader.cpp
+        index/BackgroundIndexStorage.cpp
+        index/BackgroundQueue.cpp
+        index/BackgroundRebuild.cpp
+        index/CanonicalIncludes.cpp
+        index/FileIndex.cpp
+        index/Index.cpp
+        index/IndexAction.cpp
+        index/MemIndex.cpp
+        index/Merge.cpp
+        index/ProjectAware.cpp
+        index/Ref.cpp
+        index/Relation.cpp
+        index/Serialization.cpp
+        index/Symbol.cpp
+        index/SymbolCollector.cpp
+        index/SymbolID.cpp
+        index/SymbolLocation.cpp
+        index/SymbolOrigin.cpp
+        index/YAMLSerialization.cpp
+
+        index/dex/Dex.cpp
+        index/dex/Iterator.cpp
+        index/dex/PostingList.cpp
+        index/dex/Trigram.cpp
+
+        refactor/Rename.cpp
+        refactor/Tweak.cpp
+
+        DEPENDS
+        omp_gen
+        )
+
+# Include generated CompletionModel headers.
+target_include_directories(3cClangDaemon PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+        )
+
+clang_target_link_libraries(3cClangDaemon
+        PRIVATE
+        clangAST
+        clangASTMatchers
+        clangBasic
+        clang3C
+        clangDriver
+        clangFormat
+        clangFrontend
+        clangIndex
+        clangLex
+        clangSema
+        clangSerialization
+        clangTooling
+        clangToolingCore
+        clangToolingInclusions
+        clangToolingSyntax
+        )
+
+target_link_libraries(3cClangDaemon
+        PRIVATE
+        ${LLVM_PTHREAD_LIB}
+
+        clangTidy
+        ${ALL_CLANG_TIDY_CHECKS}
+
+        clangdSupport
+        )
+target_compile_definitions(obj.3cClangDaemon PRIVATE LSP3C=1)
 add_subdirectory(refactor/tweaks)
 if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
   # FIXME: Make fuzzer not use linux-specific APIs, build it everywhere.

--- a/clang-tools-extra/clangd/CMakeLists.txt
+++ b/clang-tools-extra/clangd/CMakeLists.txt
@@ -49,6 +49,7 @@ add_clang_library(clangDaemon
   ASTSignals.cpp
   ClangdLSPServer.cpp
   ClangdServer.cpp
+  3CCommands.cpp
   3CDiagnostics.cpp
   CodeComplete.cpp
   CodeCompletionStrings.cpp
@@ -164,6 +165,7 @@ add_clang_library(3cClangDaemon
         ASTSignals.cpp
         ClangdLSPServer.cpp
         ClangdServer.cpp
+        3CCommands.cpp
         3CDiagnostics.cpp
         CodeComplete.cpp
         CodeCompletionStrings.cpp

--- a/clang-tools-extra/clangd/CMakeLists.txt
+++ b/clang-tools-extra/clangd/CMakeLists.txt
@@ -49,6 +49,7 @@ add_clang_library(clangDaemon
   ASTSignals.cpp
   ClangdLSPServer.cpp
   ClangdServer.cpp
+  3CDiagnostics.cpp
   CodeComplete.cpp
   CodeCompletionStrings.cpp
   CollectMacros.cpp
@@ -163,6 +164,7 @@ add_clang_library(3cClangDaemon
         ASTSignals.cpp
         ClangdLSPServer.cpp
         ClangdServer.cpp
+        3CDiagnostics.cpp
         CodeComplete.cpp
         CodeCompletionStrings.cpp
         CollectMacros.cpp

--- a/clang-tools-extra/clangd/ClangdLSPServer.cpp
+++ b/clang-tools-extra/clangd/ClangdLSPServer.cpp
@@ -1479,6 +1479,12 @@ void ClangdLSPServer::onAST(const ASTParams &Params,
   Server->getAST(Params.textDocument.uri.file(), Params.range, std::move(CB));
 }
 
+void ClangdLSPServer::onRun3c(Callback<llvm::Optional<_3CStats>> Reply) {
+  _3CStats ST;
+  ST.Details="Hello from the beautiful server Clangd";
+  Reply(std::move(ST));
+
+}
 ClangdLSPServer::ClangdLSPServer(class Transport &Transp,
                                  const ThreadsafeFS &TFS,
                                  const ClangdLSPServer::Options &Opts)
@@ -1502,6 +1508,7 @@ ClangdLSPServer::ClangdLSPServer(class Transport &Transp,
   MsgHandler->bind("initialized", &ClangdLSPServer::onInitialized);
   MsgHandler->bind("shutdown", &ClangdLSPServer::onShutdown);
   MsgHandler->bind("sync", &ClangdLSPServer::onSync);
+  MsgHandler->bind("textDocument/run3c",&ClangdLSPServer::onRun3c);
   MsgHandler->bind("textDocument/rangeFormatting", &ClangdLSPServer::onDocumentRangeFormatting);
   MsgHandler->bind("textDocument/onTypeFormatting", &ClangdLSPServer::onDocumentOnTypeFormatting);
   MsgHandler->bind("textDocument/formatting", &ClangdLSPServer::onDocumentFormatting);
@@ -1746,6 +1753,7 @@ void ClangdLSPServer::reparseOpenFilesIfNeeded(
                             encodeVersion(Draft->Version),
                             WantDiagnostics::Auto);
 }
+
 
 } // namespace clangd
 } // namespace clang

--- a/clang-tools-extra/clangd/ClangdLSPServer.cpp
+++ b/clang-tools-extra/clangd/ClangdLSPServer.cpp
@@ -760,7 +760,6 @@ void ClangdLSPServer::_3CisDone(std::string FileName,
                                       bool ClearDiags) {
   // Get the diagnostics and update the client.
   std::vector<Diag> Diagnostics;
-  log("In  3c is Done: Part 1");
   Diagnostics.clear();
   if (!ClearDiags) {
     std::lock_guard<std::mutex> lock(Server->DiagInfofor3C.DiagMutex);
@@ -1758,7 +1757,8 @@ void ClangdLSPServer::onDiagnosticsReady(PathRef File, llvm::StringRef Version,
                  Notification.diagnostics.push_back(std::move(Diag));
                });
   }
-
+  auto size = Diagnostics.size();
+  log(std::to_string(size).c_str());
   publishDiagnostics(Notification);
 #else
   PublishDiagnosticsParams Notification;

--- a/clang-tools-extra/clangd/ClangdLSPServer.cpp
+++ b/clang-tools-extra/clangd/ClangdLSPServer.cpp
@@ -18,7 +18,9 @@
 #include "SourceCode.h"
 #include "TUScheduler.h"
 #include "URI.h"
+#ifdef LSP3C
 #include "clang/3C/3C.h"
+#endif
 #include "refactor/Tweak.h"
 #include "support/Context.h"
 #include "support/MemoryTree.h"
@@ -1479,7 +1481,7 @@ void ClangdLSPServer::onAST(const ASTParams &Params,
                             Callback<llvm::Optional<ASTNode>> CB) {
   Server->getAST(Params.textDocument.uri.file(), Params.range, std::move(CB));
 }
-
+#ifdef LSP3C
 void ClangdLSPServer::onRun3c(Callback<llvm::Optional<_3CStats>> Reply) {
   _3CStats ST;
   ST.Details="You just ran the 3C command.";
@@ -1492,10 +1494,14 @@ void ClangdLSPServer::onRun3c(Callback<llvm::Optional<_3CStats>> Reply) {
   elog("Done converting successfully");
 
 }
+#endif
 ClangdLSPServer::ClangdLSPServer(class Transport &Transp,
                                  const ThreadsafeFS &TFS,
-                                 const ClangdLSPServer::Options &Opts,
-                                 _3CInterface &_3CInterface)
+#ifdef LSP3C
+                                 const ClangdLSPServer::Options &Opts, _3CInterface &_3CInterface)
+#else
+                                 const ClangdLSPServer::Options &Opts)
+#endif
     : ShouldProfile(/*Period=*/std::chrono::minutes(5),
                     /*Delay=*/std::chrono::minutes(1)),
       ShouldCleanupMemory(/*Period=*/std::chrono::minutes(1),
@@ -1518,7 +1524,9 @@ ClangdLSPServer::ClangdLSPServer(class Transport &Transp,
   MsgHandler->bind("initialized", &ClangdLSPServer::onInitialized);
   MsgHandler->bind("shutdown", &ClangdLSPServer::onShutdown);
   MsgHandler->bind("sync", &ClangdLSPServer::onSync);
+#ifdef LSP3C
   MsgHandler->bind("textDocument/run3c",&ClangdLSPServer::onRun3c);
+#endif
   MsgHandler->bind("textDocument/rangeFormatting", &ClangdLSPServer::onDocumentRangeFormatting);
   MsgHandler->bind("textDocument/onTypeFormatting", &ClangdLSPServer::onDocumentOnTypeFormatting);
   MsgHandler->bind("textDocument/formatting", &ClangdLSPServer::onDocumentFormatting);

--- a/clang-tools-extra/clangd/ClangdLSPServer.cpp
+++ b/clang-tools-extra/clangd/ClangdLSPServer.cpp
@@ -1484,14 +1484,11 @@ void ClangdLSPServer::onAST(const ASTParams &Params,
 #ifdef LSP3C
 void ClangdLSPServer::onRun3c(Callback<llvm::Optional<_3CStats>> Reply) {
   _3CStats ST;
-  ST.Details="You just ran the 3C command.";
+  ST.Details="You just ran the 3C command on the Project";
   Reply(std::move(ST));
-  _3CInter.parseASTs();
-  _3CInter.addVariables();
-  _3CInter.buildInitialConstraints();
-  _3CInter.solveConstraints();
-  _3CInter.writeAllConvertedFilesToDisk();
-  elog("Done converting successfully");
+  Server->execute3CCommand(_3CInter);
+  elog("Done converting successfully now in "
+       "LSP Server part of clangd");
 
 }
 #endif

--- a/clang-tools-extra/clangd/ClangdLSPServer.cpp
+++ b/clang-tools-extra/clangd/ClangdLSPServer.cpp
@@ -602,12 +602,12 @@ void ClangdLSPServer::onInitialize(const InitializeParams &Params,
                    {"change", (int)TextDocumentSyncKind::Incremental},
                    {"save", true},
                }},
-              {"codeActionProvider", std::move(CodeActionProvider)},
+              {"codeActionProvider", true},
               {"executeCommandProvider",
                llvm::json::Object{
                    {"commands",
-                    {ExecuteCommandParams::CLANGD_APPLY_FIX_COMMAND,
-                     ExecuteCommandParams::CLANGD_APPLY_TWEAK}},
+                    {ExecuteCommandParams::_3C_APPLY_FOR_ALL,
+                     ExecuteCommandParams::_3C_APPLY_ONLY_FOR_THIS}},
                }},
 
 
@@ -802,6 +802,7 @@ void ClangdLSPServer::onFileEvent(const DidChangeWatchedFilesParams &Params) {
 void ClangdLSPServer::onCommand(const ExecuteCommandParams &Params,
                                 Callback<llvm::json::Value> Reply) {
 #ifdef LSP3C
+  elog("Command run from LSPServer");
   if (Is3CCommand(Params)){
     Server->execute3CFix(_3CInter,Params,this);
     Reply("3c Background work going on");
@@ -1110,6 +1111,7 @@ void ClangdLSPServer::onCodeAction(const CodeActionParams &Params,
   URIForFile File = Params.textDocument.uri;
   std::vector<Command> CCommands;
   for(const Diagnostic &D: Params.context.diagnostics) {
+    log("This One");
     AsCCCommands(D,CCommands);
   }
   Reply(llvm::json::Array(CCommands));

--- a/clang-tools-extra/clangd/ClangdLSPServer.cpp
+++ b/clang-tools-extra/clangd/ClangdLSPServer.cpp
@@ -718,7 +718,7 @@ void ClangdLSPServer::onDocumentDidOpen(
     const DidOpenTextDocumentParams &Params) {
 #ifdef LSP3C
   PathRef File = Params.textDocument.uri.file();
-  Server->_3COpenDocument(_3CInter,File.str(),this);
+  Server->_3COpenDocument(File.str(),this);
 #else
   PathRef File = Params.textDocument.uri.file();
 
@@ -760,6 +760,7 @@ void ClangdLSPServer::_3CisDone(std::string FileName,
                                       bool ClearDiags) {
   // Get the diagnostics and update the client.
   std::vector<Diag> Diagnostics;
+  log("In  3c is Done: Part 1");
   Diagnostics.clear();
   if (!ClearDiags) {
     std::lock_guard<std::mutex> lock(Server->DiagInfofor3C.DiagMutex);
@@ -958,7 +959,7 @@ void ClangdLSPServer::onDocumentDidClose(
   PathRef File = Params.textDocument.uri.file();
   DraftMgr.removeDraft(File);
   Server->removeDocument(File);
-#endif
+
 
   {
     std::lock_guard<std::mutex> Lock(FixItsMutex);
@@ -980,6 +981,7 @@ void ClangdLSPServer::onDocumentDidClose(
   PublishDiagnosticsParams Notification;
   Notification.uri = URIForFile::canonicalize(File, /*TUPath=*/File);
   publishDiagnostics(Notification);
+#endif
 }
 
 void ClangdLSPServer::onDocumentOnTypeFormatting(
@@ -1577,6 +1579,9 @@ void ClangdLSPServer::onRun3c(Callback<llvm::Optional<_3CStats>> Reply) {
   ST.Details="You just ran the 3C command on the Project";
   Reply(std::move(ST));
   Server->execute3CCommand(_3CInter, this);
+/*
+  Server->secondrun3C(_3CInter,this);
+*/
     elog("Done converting successfully now in "
          "LSP Server part of clangd");
 

--- a/clang-tools-extra/clangd/ClangdLSPServer.cpp
+++ b/clang-tools-extra/clangd/ClangdLSPServer.cpp
@@ -1482,13 +1482,14 @@ void ClangdLSPServer::onAST(const ASTParams &Params,
 
 void ClangdLSPServer::onRun3c(Callback<llvm::Optional<_3CStats>> Reply) {
   _3CStats ST;
-  ST.Details="Hello from the beautiful server Clangd";
+  ST.Details="You just ran the 3C command.";
   Reply(std::move(ST));
   _3CInter.parseASTs();
   _3CInter.addVariables();
   _3CInter.buildInitialConstraints();
   _3CInter.solveConstraints();
   _3CInter.writeAllConvertedFilesToDisk();
+  elog("Done converting successfully");
 
 }
 ClangdLSPServer::ClangdLSPServer(class Transport &Transp,

--- a/clang-tools-extra/clangd/ClangdLSPServer.h
+++ b/clang-tools-extra/clangd/ClangdLSPServer.h
@@ -15,6 +15,7 @@
 #include "FindSymbols.h"
 #include "GlobalCompilationDatabase.h"
 #include "Protocol.h"
+#include "clang/3C/3C.h"
 #include "Transport.h"
 #include "support/Context.h"
 #include "support/MemoryTree.h"
@@ -66,7 +67,7 @@ public:
   };
 
   ClangdLSPServer(Transport &Transp, const ThreadsafeFS &TFS,
-                  const ClangdLSPServer::Options &Opts);
+                  const ClangdLSPServer::Options &Opts,_3CInterface &_3CInterface);
   /// The destructor blocks on any outstanding background tasks.
   ~ClangdLSPServer();
 
@@ -319,6 +320,8 @@ private:
   llvm::Optional<OverlayCDB> CDB;
   // The ClangdServer is created by the "initialize" LSP method.
   llvm::Optional<ClangdServer> Server;
+
+  _3CInterface &_3CInter;
 };
 } // namespace clangd
 } // namespace clang

--- a/clang-tools-extra/clangd/ClangdLSPServer.h
+++ b/clang-tools-extra/clangd/ClangdLSPServer.h
@@ -41,7 +41,11 @@ class SymbolIndex;
 /// MessageHandler binds the implemented LSP methods (e.g. onInitialize) to
 /// corresponding JSON-RPC methods ("initialize").
 /// The server also supports $/cancelRequest (MessageHandler provides this).
+#ifdef LSP3C
+class ClangdLSPServer : private ClangdServer::Callbacks, public ClangdServer::_3CLSPCallBack {
+#else
 class ClangdLSPServer : private ClangdServer::Callbacks {
+#endif
 public:
   struct Options : ClangdServer::Options {
     /// Supplies configuration (overrides ClangdServer::ContextProvider).
@@ -93,10 +97,6 @@ private:
   // Implement ClangdServer::Callbacks.
   void onDiagnosticsReady(PathRef File, llvm::StringRef Version,
                           std::vector<Diag> Diagnostics) override;
-#ifdef LSP3C
-  void onDiagnosticsReady(PathRef File,
-                          std::vector<Diag> Diagnostics) ;
-#endif
   void onFileUpdated(PathRef File, const TUStatus &Status) override;
   void
   onHighlightingsReady(PathRef File, llvm::StringRef Version,

--- a/clang-tools-extra/clangd/ClangdLSPServer.h
+++ b/clang-tools-extra/clangd/ClangdLSPServer.h
@@ -162,6 +162,7 @@ private:
   /// This is a clangd extension. Provides a json tree representing memory usage
   /// hierarchy.
   void onMemoryUsage(Callback<MemoryTree>);
+  void onRun3c(Callback<llvm::Optional<_3CStats>>);
 
   std::vector<Fix> getFixes(StringRef File, const clangd::Diagnostic &D);
 

--- a/clang-tools-extra/clangd/ClangdLSPServer.h
+++ b/clang-tools-extra/clangd/ClangdLSPServer.h
@@ -15,7 +15,9 @@
 #include "FindSymbols.h"
 #include "GlobalCompilationDatabase.h"
 #include "Protocol.h"
+#ifdef LSP3C
 #include "clang/3C/3C.h"
+#endif
 #include "Transport.h"
 #include "support/Context.h"
 #include "support/MemoryTree.h"
@@ -67,7 +69,11 @@ public:
   };
 
   ClangdLSPServer(Transport &Transp, const ThreadsafeFS &TFS,
+#ifdef LSP3C
                   const ClangdLSPServer::Options &Opts,_3CInterface &_3CInterface);
+#else
+                  const ClangdLSPServer::Options &Opts);
+#endif
   /// The destructor blocks on any outstanding background tasks.
   ~ClangdLSPServer();
 
@@ -163,7 +169,9 @@ private:
   /// This is a clangd extension. Provides a json tree representing memory usage
   /// hierarchy.
   void onMemoryUsage(Callback<MemoryTree>);
+#ifdef LSP3C
   void onRun3c(Callback<llvm::Optional<_3CStats>>);
+#endif
 
   std::vector<Fix> getFixes(StringRef File, const clangd::Diagnostic &D);
 
@@ -320,8 +328,9 @@ private:
   llvm::Optional<OverlayCDB> CDB;
   // The ClangdServer is created by the "initialize" LSP method.
   llvm::Optional<ClangdServer> Server;
-
+#ifdef LSP3C
   _3CInterface &_3CInter;
+#endif
 };
 } // namespace clangd
 } // namespace clang

--- a/clang-tools-extra/clangd/ClangdLSPServer.h
+++ b/clang-tools-extra/clangd/ClangdLSPServer.h
@@ -85,11 +85,18 @@ public:
 
   /// Profiles resource-usage.
   void profile(MemoryTree &MT) const;
-
+#ifdef LSP3C
+  void _3CisDone(std::string FileName, bool ClearDiags = false) override;
+  void sendMessage(std::string Msg) override;
+#endif
 private:
   // Implement ClangdServer::Callbacks.
   void onDiagnosticsReady(PathRef File, llvm::StringRef Version,
                           std::vector<Diag> Diagnostics) override;
+#ifdef LSP3C
+  void onDiagnosticsReady(PathRef File,
+                          std::vector<Diag> Diagnostics) ;
+#endif
   void onFileUpdated(PathRef File, const TUStatus &Status) override;
   void
   onHighlightingsReady(PathRef File, llvm::StringRef Version,

--- a/clang-tools-extra/clangd/ClangdServer.cpp
+++ b/clang-tools-extra/clangd/ClangdServer.cpp
@@ -283,7 +283,16 @@ ClangdServer::createConfiguredContextProvider(const config::Provider *Provider,
     return (*I)(Path);
   };
 }
-
+#ifdef LSP3C
+void ClangdServer::execute3CCommand(_3CInterface &LSPInter) {
+    LSPInter.parseASTs();
+    LSPInter.addVariables();
+    LSPInter.buildInitialConstraints();
+    LSPInter.solveConstraints();
+    LSPInter.writeAllConvertedFilesToDisk();
+    elog("exiting the ClangdServer after this");
+}
+#endif
 void ClangdServer::removeDocument(PathRef File) { WorkScheduler.remove(File); }
 
 void ClangdServer::codeComplete(PathRef File, Position Pos,

--- a/clang-tools-extra/clangd/ClangdServer.cpp
+++ b/clang-tools-extra/clangd/ClangdServer.cpp
@@ -208,20 +208,20 @@ void ClangdServer::addDocument(PathRef File, llvm::StringRef Contents,
 }
 #ifdef LSP3C
 
-void ClangdServer::report3CDiagsForAllFiles(ConstraintsInfo &CcInfo, Callbacks *ConvCB) {
+void ClangdServer::report3CDiagsForAllFiles(ConstraintsInfo &CcInfo, _3CLSPCallBack *ConvCB) {
   for (auto &SrcFileDiags : DiagInfofor3C.GetAllFilesDiagnostics()) {
     ConvCB->_3CisDone(SrcFileDiags.first);
   }
 }
 
 void ClangdServer::clear3CDiagsForAllFiles(ConstraintsInfo &CcInfo,
-                                           Callbacks *ConvCB) {
+                                           _3CLSPCallBack *ConvCB) {
   for (auto &SrcFileDiags : DiagInfofor3C.GetAllFilesDiagnostics()) {
     // Clear diags for all files.
     ConvCB->_3CisDone(SrcFileDiags.first, true);
   }
 }
-void ClangdServer::execute3CCommand(_3CInterface &LSPInter,Callbacks *TCCB) {
+void ClangdServer::execute3CCommand(_3CInterface &LSPInter,_3CLSPCallBack *TCCB) {
   DiagInfofor3C.ClearAllDiags();
   TCCB->sendMessage("Running 3C");
   LSPInter.parseASTs();

--- a/clang-tools-extra/clangd/ClangdServer.h
+++ b/clang-tools-extra/clangd/ClangdServer.h
@@ -369,8 +369,11 @@ public:
   //These are 3C specific commands on ClangdServer
 
   void execute3CCommand(_3CInterface &, _3CLSPCallBack *ConvCB);
+  void execute3CFix(_3CInterface &,ExecuteCommandParams Params,
+                    _3CLSPCallBack *ConvCB);
   _3CDiagnostics DiagInfofor3C;
-  void _3COpenDocument(std::string FileName,_3CLSPCallBack *ConvCB);
+  void _3COpenDocument(_3CInterface &,std::string FileName,
+                       _3CLSPCallBack *ConvCB);
   void _3CCloseDocument(std::string FileName,_3CLSPCallBack *ConvCB);
 #endif
 

--- a/clang-tools-extra/clangd/ClangdServer.h
+++ b/clang-tools-extra/clangd/ClangdServer.h
@@ -83,14 +83,20 @@ public:
     /// Not called concurrently.
     virtual void
     onBackgroundIndexProgress(const BackgroundQueue::Stats &Stats) {}
+
+  };
 #ifdef LSP3C
+  class _3CLSPCallBack {
+  public:
+    virtual ~_3CLSPCallBack() = default;
     virtual void
     _3CisDone(std::string FileName,
               bool ClearDiags = false) = 0;
     virtual void
     sendMessage(std::string Msg) = 0;
-#endif
   };
+
+#endif
   /// Creates a context provider that loads and installs config.
   /// Errors in loading config are reported as diagnostics via Callbacks.
   /// (This is typically used as ClangdServer::Options::ContextProvider).
@@ -362,7 +368,7 @@ public:
 #ifdef LSP3C
   //These are 3C specific commands on ClangdServer
 
-  void execute3CCommand(_3CInterface &, Callbacks *TCCB);
+  void execute3CCommand(_3CInterface &, _3CLSPCallBack *ConvCB);
   _3CDiagnostics DiagInfofor3C;
 #endif
 
@@ -377,8 +383,8 @@ private:
   const GlobalCompilationDatabase &CDB;
   const ThreadsafeFS &TFS;
 #ifdef LSP3C
-  void report3CDiagsForAllFiles(ConstraintsInfo &CcInfo, Callbacks *ConvCB);
-  void clear3CDiagsForAllFiles(ConstraintsInfo &CcInfo, Callbacks *ConvCB);
+  void report3CDiagsForAllFiles(ConstraintsInfo &CcInfo, _3CLSPCallBack *ConvCB);
+  void clear3CDiagsForAllFiles(ConstraintsInfo &CcInfo, _3CLSPCallBack *ConvCB);
 #endif
   Path ResourceDir;
   // The index used to look up symbols. This could be:

--- a/clang-tools-extra/clangd/ClangdServer.h
+++ b/clang-tools-extra/clangd/ClangdServer.h
@@ -369,10 +369,11 @@ public:
   //These are 3C specific commands on ClangdServer
 
   void execute3CCommand(_3CInterface &, _3CLSPCallBack *ConvCB);
+  void secondrun3C(_3CInterface &, _3CLSPCallBack *ConvCB);
   void execute3CFix(_3CInterface &,ExecuteCommandParams Params,
                     _3CLSPCallBack *ConvCB);
   _3CDiagnostics DiagInfofor3C;
-  void _3COpenDocument(_3CInterface &,std::string FileName,
+  void _3COpenDocument(std::string FileName,
                        _3CLSPCallBack *ConvCB);
   void _3CCloseDocument(std::string FileName,_3CLSPCallBack *ConvCB);
 #endif

--- a/clang-tools-extra/clangd/ClangdServer.h
+++ b/clang-tools-extra/clangd/ClangdServer.h
@@ -370,6 +370,8 @@ public:
 
   void execute3CCommand(_3CInterface &, _3CLSPCallBack *ConvCB);
   _3CDiagnostics DiagInfofor3C;
+  void _3COpenDocument(std::string FileName,_3CLSPCallBack *ConvCB);
+  void _3CCloseDocument(std::string FileName,_3CLSPCallBack *ConvCB);
 #endif
 
   /// Builds a nested representation of memory used by components.
@@ -384,6 +386,7 @@ private:
   const ThreadsafeFS &TFS;
 #ifdef LSP3C
   void report3CDiagsForAllFiles(ConstraintsInfo &CcInfo, _3CLSPCallBack *ConvCB);
+  void report3CDiagsforFile(std::string FileName, _3CLSPCallBack *ConvCB);
   void clear3CDiagsForAllFiles(ConstraintsInfo &CcInfo, _3CLSPCallBack *ConvCB);
 #endif
   Path ResourceDir;

--- a/clang-tools-extra/clangd/ClangdServer.h
+++ b/clang-tools-extra/clangd/ClangdServer.h
@@ -38,6 +38,9 @@
 #include <string>
 #include <type_traits>
 #include <utility>
+#ifdef LSP3C
+#include <clang/3C/3C.h>
+#endif
 
 namespace clang {
 namespace clangd {
@@ -348,6 +351,9 @@ public:
   // Returns false if the timeout expires.
   LLVM_NODISCARD bool
   blockUntilIdleForTest(llvm::Optional<double> TimeoutSeconds = 10);
+#ifdef LSP3C
+  void execute3CCommand(_3CInterface &);
+#endif
 
   /// Builds a nested representation of memory used by components.
   void profile(MemoryTree &MT) const;

--- a/clang-tools-extra/clangd/ClangdServer.h
+++ b/clang-tools-extra/clangd/ClangdServer.h
@@ -40,6 +40,7 @@
 #include <utility>
 #ifdef LSP3C
 #include <clang/3C/3C.h>
+#include "3CDiagnostics.h"
 #endif
 
 namespace clang {
@@ -82,6 +83,13 @@ public:
     /// Not called concurrently.
     virtual void
     onBackgroundIndexProgress(const BackgroundQueue::Stats &Stats) {}
+#ifdef LSP3C
+    virtual void
+    _3CisDone(std::string FileName,
+              bool ClearDiags = false) = 0;
+    virtual void
+    sendMessage(std::string Msg) = 0;
+#endif
   };
   /// Creates a context provider that loads and installs config.
   /// Errors in loading config are reported as diagnostics via Callbacks.
@@ -352,7 +360,10 @@ public:
   LLVM_NODISCARD bool
   blockUntilIdleForTest(llvm::Optional<double> TimeoutSeconds = 10);
 #ifdef LSP3C
-  void execute3CCommand(_3CInterface &);
+  //These are 3C specific commands on ClangdServer
+
+  void execute3CCommand(_3CInterface &, Callbacks *TCCB);
+  _3CDiagnostics DiagInfofor3C;
 #endif
 
   /// Builds a nested representation of memory used by components.
@@ -365,7 +376,10 @@ private:
 
   const GlobalCompilationDatabase &CDB;
   const ThreadsafeFS &TFS;
-
+#ifdef LSP3C
+  void report3CDiagsForAllFiles(ConstraintsInfo &CcInfo, Callbacks *ConvCB);
+  void clear3CDiagsForAllFiles(ConstraintsInfo &CcInfo, Callbacks *ConvCB);
+#endif
   Path ResourceDir;
   // The index used to look up symbols. This could be:
   //   - null (all index functionality is optional)

--- a/clang-tools-extra/clangd/Diagnostics.cpp
+++ b/clang-tools-extra/clangd/Diagnostics.cpp
@@ -412,6 +412,14 @@ void toLSPDiags(
   // Main diagnostic should always refer to a range inside main file. If a
   // diagnostic made it so for, it means either itself or one of its notes is
   // inside main file.
+#ifdef LSP3C
+  auto FillBasicFields = [](const DiagBase &D) -> clangd::Diagnostic {
+    clangd::Diagnostic Res;
+    Res.range = D.Range;
+    Res.severity = getSeverity(D.Severity);
+    return Res;
+  };
+#else
   if (D.InsideMainFile) {
     Main.range = D.Range;
   } else {
@@ -421,8 +429,12 @@ void toLSPDiags(
            "neither the main diagnostic nor notes are inside main file");
     Main.range = It->Range;
   }
-
+#endif
+#ifdef LSP3C
+  Main.code  = D.code;
+#else
   Main.code = D.Name;
+#endif
 
   switch (D.Source) {
   case Diag::Clang:

--- a/clang-tools-extra/clangd/Diagnostics.cpp
+++ b/clang-tools-extra/clangd/Diagnostics.cpp
@@ -418,7 +418,9 @@ void toLSPDiags(
     Res.range = D.Range;
     Res.severity = getSeverity(D.Severity);
     return Res;
+
   };
+  Main = FillBasicFields(D);
 #else
   if (D.InsideMainFile) {
     Main.range = D.Range;

--- a/clang-tools-extra/clangd/Diagnostics.cpp
+++ b/clang-tools-extra/clangd/Diagnostics.cpp
@@ -423,6 +423,7 @@ void toLSPDiags(
   }
 
   Main.code = D.Name;
+
   switch (D.Source) {
   case Diag::Clang:
     Main.source = "clang";
@@ -433,6 +434,11 @@ void toLSPDiags(
   case Diag::ClangdConfig:
     Main.source = "clangd-config";
     break;
+#ifdef LSP3C
+  case Diag::Main3C:
+      Main.source = "3C_RealWild";
+      break;
+#endif
   case Diag::Unknown:
     break;
   }

--- a/clang-tools-extra/clangd/Diagnostics.h
+++ b/clang-tools-extra/clangd/Diagnostics.h
@@ -59,6 +59,9 @@ struct DiagBase {
   std::string File;
   // Absolute path to containing file, if available.
   llvm::Optional<std::string> AbsFile;
+#ifdef LSP3C
+  std::string code;
+#endif
 
   clangd::Range Range;
   DiagnosticsEngine::Level Severity = DiagnosticsEngine::Note;
@@ -92,6 +95,9 @@ struct Diag : DiagBase {
     Clang,
     ClangTidy,
     ClangdConfig,
+#ifdef LSP3C
+    Main3C,
+#endif
   } Source = Unknown;
   /// Elaborate on the problem, usually pointing to a related piece of code.
   std::vector<Note> Notes;

--- a/clang-tools-extra/clangd/Protocol.cpp
+++ b/clang-tools-extra/clangd/Protocol.cpp
@@ -1393,6 +1393,13 @@ llvm::json::Value toJSON(const ASTNode &N) {
   return Result;
 }
 
+
+llvm::json::Value toJSON(const _3CStats &ST) {
+  llvm::json::Object Reply{
+    {"details",ST.Details}
+  };
+  return Reply;
+}
 llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, const ASTNode &Root) {
   std::function<void(const ASTNode &, unsigned)> Print = [&](const ASTNode &N,
                                                              unsigned Level) {

--- a/clang-tools-extra/clangd/Protocol.cpp
+++ b/clang-tools-extra/clangd/Protocol.cpp
@@ -1393,6 +1393,11 @@ llvm::json::Value toJSON(const ASTNode &N) {
   return Result;
 }
 
+bool fromJSON(const llvm::json::Value &Params, _3CParams &R,
+              llvm::json::Path P) {
+  llvm::json::ObjectMapper O(Params, P);
+  return O && O.map("textDocument", R.textDocument);
+}
 
 llvm::json::Value toJSON(const _3CStats &ST) {
   llvm::json::Object Reply{

--- a/clang-tools-extra/clangd/Protocol.cpp
+++ b/clang-tools-extra/clangd/Protocol.cpp
@@ -639,7 +639,21 @@ bool fromJSON(const llvm::json::Value &Params, WorkspaceEdit &R,
   llvm::json::ObjectMapper O(Params, P);
   return O && O.map("changes", R.changes);
 }
+#ifdef LSP3C
+bool fromJSON(const llvm::json::Value &Params, _3CManualFix &CCM,llvm::json::Path P) {
+  llvm::json::ObjectMapper O(Params,P);
+  CCM.ptrID = (*Params.getAsObject()->getInteger("ptrID"));
+  return O;
+}
 
+llvm::json::Value toJSON(const _3CManualFix &WE) {
+  return llvm::json::Object{{"ptrID", std::move(WE.ptrID)}};
+}
+const llvm::StringLiteral ExecuteCommandParams::_3C_APPLY_ONLY_FOR_THIS =
+    "3c.onlyThisPtr";
+const llvm::StringLiteral ExecuteCommandParams::_3C_APPLY_FOR_ALL =
+    "3c.applyAllPtr";
+#endif
 const llvm::StringLiteral ExecuteCommandParams::CLANGD_APPLY_FIX_COMMAND =
     "clangd.applyFix";
 const llvm::StringLiteral ExecuteCommandParams::CLANGD_APPLY_TWEAK =
@@ -660,6 +674,15 @@ bool fromJSON(const llvm::json::Value &Params, ExecuteCommandParams &R,
   if (R.command == ExecuteCommandParams::CLANGD_APPLY_TWEAK)
     return Args && Args->size() == 1 &&
            fromJSON(Args->front(), R.tweakArgs, P.field("arguments").index(0));
+
+#ifdef LSP3C
+  if (R.command == ExecuteCommandParams::_3C_APPLY_ONLY_FOR_THIS ||
+      R.command == ExecuteCommandParams::_3C_APPLY_FOR_ALL) {
+    return Args && Args->size() == 1 &&
+           fromJSON(Args->front(), R._3CFix,
+                    P.field("arguments").index(0));
+  }
+#endif
   return false; // Unrecognized command.
 }
 
@@ -732,6 +755,10 @@ llvm::json::Value toJSON(const Command &C) {
     Cmd["arguments"] = {*C.workspaceEdit};
   if (C.tweakArgs)
     Cmd["arguments"] = {*C.tweakArgs};
+#ifdef LSP3C
+  if(C._3CFix)
+    Cmd["arguments"] = {*C._3CFix};
+#endif
   return std::move(Cmd);
 }
 

--- a/clang-tools-extra/clangd/Protocol.cpp
+++ b/clang-tools-extra/clangd/Protocol.cpp
@@ -1392,7 +1392,7 @@ llvm::json::Value toJSON(const ASTNode &N) {
     Result["range"] = *N.range;
   return Result;
 }
-
+#ifdef LSP3C
 bool fromJSON(const llvm::json::Value &Params, _3CParams &R,
               llvm::json::Path P) {
   llvm::json::ObjectMapper O(Params, P);
@@ -1405,6 +1405,7 @@ llvm::json::Value toJSON(const _3CStats &ST) {
   };
   return Reply;
 }
+#endif
 llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, const ASTNode &Root) {
   std::function<void(const ASTNode &, unsigned)> Print = [&](const ASTNode &N,
                                                              unsigned Level) {

--- a/clang-tools-extra/clangd/Protocol.h
+++ b/clang-tools-extra/clangd/Protocol.h
@@ -1696,6 +1696,11 @@ struct ASTParams {
 };
 bool fromJSON(const llvm::json::Value &, ASTParams &, llvm::json::Path);
 
+
+struct _3CStats {
+  std::string Details;
+};
+llvm::json::Value toJSON(const _3CStats &);
 /// Simplified description of a clang AST node.
 /// This is clangd's internal representation of C++ code.
 struct ASTNode {

--- a/clang-tools-extra/clangd/Protocol.h
+++ b/clang-tools-extra/clangd/Protocol.h
@@ -899,6 +899,16 @@ struct WorkspaceEdit {
 bool fromJSON(const llvm::json::Value &, WorkspaceEdit &, llvm::json::Path);
 llvm::json::Value toJSON(const WorkspaceEdit &WE);
 
+
+#ifdef LSP3C
+
+struct _3CManualFix{
+  int ptrID;
+};
+
+bool fromJSON(const llvm::json::Value &, _3CManualFix &, llvm::json::Path);
+llvm::json::Value toJSON(const _3CManualFix &WE);
+#endif
 /// Arguments for the 'applyTweak' command. The server sends these commands as a
 /// response to the textDocument/codeAction request. The client can later send a
 /// command back to the server if the user requests to execute a particular code
@@ -927,6 +937,12 @@ struct ExecuteCommandParams {
   const static llvm::StringLiteral CLANGD_APPLY_FIX_COMMAND;
   // Command to apply the code action. Uses TweakArgs as argument.
   const static llvm::StringLiteral CLANGD_APPLY_TWEAK;
+#ifdef LSP3C
+  // Command to apply the change for this pointer only
+  const static llvm::StringLiteral _3C_APPLY_ONLY_FOR_THIS;
+  // Command to apply the change for all pointers with same reason
+  const static llvm::StringLiteral _3C_APPLY_FOR_ALL;
+#endif
 
   /// The command identifier, e.g. CLANGD_APPLY_FIX_COMMAND
   std::string command;
@@ -934,6 +950,9 @@ struct ExecuteCommandParams {
   // Arguments
   llvm::Optional<WorkspaceEdit> workspaceEdit;
   llvm::Optional<TweakArgs> tweakArgs;
+#ifdef LSP3C
+  llvm::Optional<_3CManualFix> _3CFix;
+#endif
 };
 bool fromJSON(const llvm::json::Value &, ExecuteCommandParams &,
               llvm::json::Path);

--- a/clang-tools-extra/clangd/Protocol.h
+++ b/clang-tools-extra/clangd/Protocol.h
@@ -1695,7 +1695,7 @@ struct ASTParams {
   Range range;
 };
 bool fromJSON(const llvm::json::Value &, ASTParams &, llvm::json::Path);
-
+#ifdef LSP3C
 struct _3CParams{
   TextDocumentIdentifier textDocument;
 };
@@ -1705,6 +1705,7 @@ struct _3CStats {
   std::string Details;
 };
 llvm::json::Value toJSON(const _3CStats &);
+#endif
 /// Simplified description of a clang AST node.
 /// This is clangd's internal representation of C++ code.
 struct ASTNode {

--- a/clang-tools-extra/clangd/Protocol.h
+++ b/clang-tools-extra/clangd/Protocol.h
@@ -1696,7 +1696,11 @@ struct ASTParams {
 };
 bool fromJSON(const llvm::json::Value &, ASTParams &, llvm::json::Path);
 
+struct _3CParams{
+  TextDocumentIdentifier textDocument;
+};
 
+bool fromJSON(const llvm::json::Value &, _3CParams &, llvm::json::Path);
 struct _3CStats {
   std::string Details;
 };

--- a/clang-tools-extra/clangd/tool/CMakeLists.txt
+++ b/clang-tools-extra/clangd/tool/CMakeLists.txt
@@ -20,6 +20,7 @@ clang_target_link_libraries(clangd
   PRIVATE
   clangAST
   clangBasic
+    clang3C
   clangFormat
   clangFrontend
   clangLex

--- a/clang-tools-extra/clangd/tool/CMakeLists.txt
+++ b/clang-tools-extra/clangd/tool/CMakeLists.txt
@@ -20,7 +20,6 @@ clang_target_link_libraries(clangd
   PRIVATE
   clangAST
   clangBasic
-    clang3C
   clangFormat
   clangFrontend
   clangLex
@@ -40,3 +39,35 @@ target_link_libraries(clangd
   clangdSupport
   ${CLANGD_XPC_LIBS}
   )
+
+add_clang_tool(3Cclangd
+        ClangdMain.cpp
+        Check.cpp
+        $<TARGET_OBJECTS:obj.clangDaemonTweaks>
+        )
+
+clang_target_link_libraries(3Cclangd
+        PRIVATE
+        clangAST
+        clangBasic
+        clang3C
+        clangFormat
+        clangFrontend
+        clangLex
+        clangSema
+        clangTooling
+        clangToolingCore
+        clangToolingRefactoring
+        clangToolingSyntax
+        )
+
+target_link_libraries(3Cclangd
+        PRIVATE
+        clangTidy
+
+        3cClangDaemon
+        clangdRemoteIndex
+        clangdSupport
+        ${CLANGD_XPC_LIBS}
+        )
+target_compile_definitions(3Cclangd PUBLIC LSP3C=1)

--- a/clang-tools-extra/clangd/tool/ClangdMain.cpp
+++ b/clang-tools-extra/clangd/tool/ClangdMain.cpp
@@ -926,20 +926,27 @@ clangd accepts flags on the commandline, and in the CLANGD_FLAGS environment var
   CcOptions.AllocatorFunctions = {};
 
   std::string ErrorMsg;
-
-  std::unique_ptr<tooling::CompilationDatabase> CompDB(
-      tooling::CompilationDatabase::autoDetectFromDirectory(CompileCommandsDir,
-                                                         ErrorMsg)
-  );
-  tooling::CompilationDatabase &_CompDB = *CompDB;
-  std::unique_ptr<_3CInterface> _3CInterfacePtr(
-      _3CInterface::create(CcOptions, CompDB->getAllFiles(),
-                           &(_CompDB)));
-  if (!_3CInterfacePtr) {
-    // _3CInterface::create has already printed an error message. Just exit.
-    return 1;
+  // This is a weird hack to go over the condition of not finding a comp DB
+  // todo Cleanup this code segment below
+  std::string FileBuf = getClangRepositoryPath();
+  if (!CompileCommandsDir.empty()){
+    FileBuf = CompileCommandsDir;
   }
+  std::unique_ptr<tooling::CompilationDatabase> CompDB(
+        tooling::CompilationDatabase::autoDetectFromDirectory(FileBuf,
+                                                              ErrorMsg)
+    );
+    tooling::CompilationDatabase &_CompDB = *CompDB;
+    std::unique_ptr<_3CInterface> _3CInterfacePtr(
+        _3CInterface::create(CcOptions, CompDB->getAllFiles(),
+                             &(_CompDB)));
+    if (!_3CInterfacePtr) {
+      // _3CInterface::create has already printed an error message. Just exit.
+      return 1;
+    }
+
   _3CInterface &_3CInter = *_3CInterfacePtr;
+
 #endif
   ClangdLSPServer LSPServer(*TransportLayer, TFS,
 #ifdef LSP3C

--- a/clang-tools-extra/clangd/tool/ClangdMain.cpp
+++ b/clang-tools-extra/clangd/tool/ClangdMain.cpp
@@ -921,8 +921,7 @@ clangd accepts flags on the commandline, and in the CLANGD_FLAGS environment var
   struct _3COptions CcOptions;
   CcOptions.AllTypes=true;
   CcOptions.AddCheckedRegions=true;
-  CcOptions.WildPtrInfoJson="output.json";
-  CcOptions.DumpIntermediate=true;
+  CcOptions.DumpIntermediate=false;
   CcOptions.OutputPostfix="checked";
   CcOptions.AllocatorFunctions = {};
 

--- a/clang-tools-extra/clangd/tool/ClangdMain.cpp
+++ b/clang-tools-extra/clangd/tool/ClangdMain.cpp
@@ -920,9 +920,12 @@ clangd accepts flags on the commandline, and in the CLANGD_FLAGS environment var
 #ifdef LSP3C
   struct _3COptions CcOptions;
   CcOptions.AllTypes=true;
-  CcOptions.AddCheckedRegions=true;
+  CcOptions.AddCheckedRegions=false;
+  CcOptions.HandleVARARGS=true;
+  CcOptions.EnableCCTypeChecker=true;
+  CcOptions.InferTypesForUndefs=true;
   CcOptions.DumpIntermediate=false;
-  CcOptions.OutputPostfix="checked";
+  CcOptions.OutputPostfix="null";
   CcOptions.AllocatorFunctions = {};
 
   std::string ErrorMsg;

--- a/clang-tools-extra/clangd/tool/ClangdMain.cpp
+++ b/clang-tools-extra/clangd/tool/ClangdMain.cpp
@@ -918,16 +918,16 @@ clangd accepts flags on the commandline, and in the CLANGD_FLAGS environment var
                                                 std::move(*Mappings));
   }
 #ifdef LSP3C
-  struct _3COptions CcOptions;
+  struct _3COptions CcOptions={0};
   CcOptions.AllTypes=true;
   CcOptions.AddCheckedRegions=false;
-  CcOptions.HandleVARARGS=true;
-  CcOptions.EnableCCTypeChecker=true;
+  CcOptions.WarnRootCause=true;
+  CcOptions.AllowUnwritableChanges=true;
+  CcOptions.ItypesForExtern=true;
   CcOptions.InferTypesForUndefs=true;
-  CcOptions.DumpIntermediate=false;
+  CcOptions.HandleVARARGS= true;
   CcOptions.OutputPostfix="null";
-  CcOptions.AllocatorFunctions = {};
-
+  CcOptions.AllocatorFunctions={};
   std::string ErrorMsg;
   // This is a weird hack to go over the condition of not finding a comp DB
   // todo Cleanup this code segment below

--- a/clang-tools-extra/clangd/tool/ClangdMain.cpp
+++ b/clang-tools-extra/clangd/tool/ClangdMain.cpp
@@ -20,6 +20,10 @@
 #include "index/Serialization.h"
 #include "index/remote/Client.h"
 #include "refactor/Rename.h"
+#ifdef LSP3C
+#include <clang/3C/3CGlobalOptions.h>
+#include "clang/3C/3C.h"
+#endif
 #include "support/Path.h"
 #include "support/Shutdown.h"
 #include "support/ThreadsafeFS.h"
@@ -52,7 +56,6 @@
 
 #ifdef __GLIBC__
 #include <malloc.h>
-#include <clang/3C/3CGlobalOptions.h>
 #endif
 
 namespace clang {
@@ -914,6 +917,7 @@ clangd accepts flags on the commandline, and in the CLANGD_FLAGS environment var
     TransportLayer = createPathMappingTransport(std::move(TransportLayer),
                                                 std::move(*Mappings));
   }
+#ifdef LSP3C
   struct _3COptions CcOptions;
   CcOptions.AllTypes=true;
   CcOptions.AddCheckedRegions=true;
@@ -937,7 +941,13 @@ clangd accepts flags on the commandline, and in the CLANGD_FLAGS environment var
     return 1;
   }
   _3CInterface &_3CInter = *_3CInterfacePtr;
-  ClangdLSPServer LSPServer(*TransportLayer, TFS, Opts,_3CInter);
+#endif
+  ClangdLSPServer LSPServer(*TransportLayer, TFS,
+#ifdef LSP3C
+                            Opts,_3CInter);
+#else
+                            Opts);
+#endif
   llvm::set_thread_name("clangd.main");
   int ExitCode = LSPServer.run()
                      ? 0

--- a/clang/docs/checkedc/3C/README.md
+++ b/clang/docs/checkedc/3C/README.md
@@ -21,8 +21,7 @@ use 3C.
 documented in [the readme there](../../../tools/3c/README.md).
 - The second method is to use a vscode extension along with
 clangd lsp plugin. Steps to build and use the plugin can be
-found [here](https://3clsp.github.io/). Note that 3CLSP is based on
-an older fork and therefore won't have the latest changes to 3C.
+found [here](https://3clsp.github.io/).
 
 ## What 3C users should know about the development process
 

--- a/clang/include/clang/3C/3C.h
+++ b/clang/include/clang/3C/3C.h
@@ -115,6 +115,7 @@ private:
 
   // Are constraints already built?
   bool ConstraintsBuilt;
+  // Remove all constraints sharing the same reason as ConstraintToRemove.
   void invalidateAllConstraintsWithReason(Constraint *ConstraintToRemove);
 };
 

--- a/clang/include/clang/3C/3C.h
+++ b/clang/include/clang/3C/3C.h
@@ -33,7 +33,7 @@ public:
   // Mutex for this interface.
   std::mutex InterfaceMutex;
 
-  bool CStateisclear=true;
+  bool CStateisclear = true;
 
   // If the parameters are invalid, this function prints an error message to
   // stderr and returns null.

--- a/clang/include/clang/3C/3C.h
+++ b/clang/include/clang/3C/3C.h
@@ -33,6 +33,8 @@ public:
   // Mutex for this interface.
   std::mutex InterfaceMutex;
 
+  bool CStateisclear=true;
+
   // If the parameters are invalid, this function prints an error message to
   // stderr and returns null.
   //
@@ -76,6 +78,8 @@ public:
   // pointers, which are wild because of the same reason, as non-wild
   // as well.
   bool invalidateWildReasonGlobally(ConstraintKey PtrKey);
+
+  void resetInterface();
 
   // Rewriting.
 

--- a/clang/include/clang/3C/3C.h
+++ b/clang/include/clang/3C/3C.h
@@ -29,7 +29,7 @@
 class _3CInterface {
 
 public:
-  ProgramInfo GlobalProgramInfo;
+  ProgramInfo * GlobalProgramInfo;
   // Mutex for this interface.
   std::mutex InterfaceMutex;
 

--- a/clang/include/clang/3C/ABounds.h
+++ b/clang/include/clang/3C/ABounds.h
@@ -124,6 +124,7 @@ public:
   mkStringWithoutLowerBound(AVarBoundsInfo *ABI, clang::Decl *D) override;
 
   bool areSame(ABounds *O, AVarBoundsInfo *ABI) override;
+  ABounds *makeCopy(BoundsKey NK) override;
 
   static bool classof(const ABounds *S) {
     return S->getKind() == CountPlusOneBoundKind;

--- a/clang/include/clang/3C/AVarBoundsConflictResolver.h
+++ b/clang/include/clang/3C/AVarBoundsConflictResolver.h
@@ -16,19 +16,21 @@
 #include "clang/3C/AVarBoundsInfo.h"
 #include "clang/3C/AVarGraph.h"
 
-class AVarBoundsConflictResolver{
-    public:
-        // Fill WorkList with conflicting bounds. This list will be later used to
-        // propogate the conflicts.
-        static void seedInitialWorkList(AVarBoundsInfo *BI, AVarGraph &BKGraph,
-                                        std::set<BoundsKey> &WorkList);
-        
-        // Using the WorkList, propogate the conflicts to all conncted Nodes in the graph
-        static void propogateConflicts(const BoundsKey &N, AVarBoundsInfo *BI,
-                                       AVarGraph &BKGraph, std::set<BoundsKey> &WorkList);
-
-        // Fix all conflicts in the graphs.
-        static void resolveConflicts(AVarBoundsInfo *BI);
+class AVarBoundsConflictResolver {
+public:
+    // Fill WorkList with conflicting bounds. This list will be later used to
+    // propogate the conflicts.
+    static void seedInitialWorkList(AVarBoundsInfo *BI,
+                                    AVarGraph &BKGraph,
+                                    std::set<BoundsKey> &WorkList);
+    
+    // Using the WorkList, propogate the conflicts to all conncted Nodes in the graph
+    static void propogateConflicts(const BoundsKey &N,
+                                   AVarBoundsInfo *BI,
+                                   AVarGraph &BKGraph, std::set<BoundsKey> &WorkList);
+    
+    // Fix all conflicts in the graphs.
+    static void resolveConflicts(AVarBoundsInfo *BI);
 };
 
 #endif // LLVM_CLANG_3C_AVARBOUNDSCONFLICTRESOLVER_H

--- a/clang/include/clang/3C/AVarBoundsConflictResolver.h
+++ b/clang/include/clang/3C/AVarBoundsConflictResolver.h
@@ -1,0 +1,34 @@
+//=--AvarBoundsConflictResolver.h---------------------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains the methods to fix bound conflicts in graphs
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_3C_AVARBOUNDSCONFLICTRESOLVER_H
+#define LLVM_CLANG_3C_AVARBOUNDSCONFLICTRESOLVER_H
+
+#include "clang/3C/AVarBoundsInfo.h"
+#include "clang/3C/AVarGraph.h"
+
+class AVarBoundsConflictResolver{
+    public:
+        // Fill WorkList with conflicting bounds. This list will be later used to
+        // propogate the conflicts.
+        static void seedInitialWorkList(AVarBoundsInfo *BI, AVarGraph &BKGraph,
+                                        std::set<BoundsKey> &WorkList);
+        
+        // Using the WorkList, propogate the conflicts to all conncted Nodes in the graph
+        static void propogateConflicts(const BoundsKey &N, AVarBoundsInfo *BI,
+                                       AVarGraph &BKGraph, std::set<BoundsKey> &WorkList);
+
+        // Fix all conflicts in the graphs.
+        static void resolveConflicts(AVarBoundsInfo *BI);
+};
+
+#endif // LLVM_CLANG_3C_AVARBOUNDSCONFLICTRESOLVER_H

--- a/clang/include/clang/3C/AVarBoundsConflictResolver.h
+++ b/clang/include/clang/3C/AVarBoundsConflictResolver.h
@@ -27,10 +27,12 @@ public:
     // Using the WorkList, propogate the conflicts to all conncted Nodes in the graph
     void propogateConflicts(const BoundsKey &N,
                             AVarBoundsInfo *BI,
-                            AVarGraph &BKGraph, std::set<BoundsKey> &WorkList);
+                            AVarGraph &BKGraph,
+                            std::set<BoundsKey> &WorkList);
     
     // Fix all conflicts in the graphs.
-    void resolveConflicts(AVarBoundsInfo *BI);
+    void resolveConflicts(AVarBoundsInfo *BI,
+                          std::set<BoundsKey> &WorkList);
 };
 
 #endif // LLVM_CLANG_3C_AVARBOUNDSCONFLICTRESOLVER_H

--- a/clang/include/clang/3C/AVarBoundsConflictResolver.h
+++ b/clang/include/clang/3C/AVarBoundsConflictResolver.h
@@ -20,17 +20,17 @@ class AVarBoundsConflictResolver {
 public:
     // Fill WorkList with conflicting bounds. This list will be later used to
     // propogate the conflicts.
-    static void seedInitialWorkList(AVarBoundsInfo *BI,
-                                    AVarGraph &BKGraph,
-                                    std::set<BoundsKey> &WorkList);
+    void seedInitialWorkList(AVarBoundsInfo *BI,
+                             AVarGraph &BKGraph,
+                             std::set<BoundsKey> &WorkList);
     
     // Using the WorkList, propogate the conflicts to all conncted Nodes in the graph
-    static void propogateConflicts(const BoundsKey &N,
-                                   AVarBoundsInfo *BI,
-                                   AVarGraph &BKGraph, std::set<BoundsKey> &WorkList);
+    void propogateConflicts(const BoundsKey &N,
+                            AVarBoundsInfo *BI,
+                            AVarGraph &BKGraph, std::set<BoundsKey> &WorkList);
     
     // Fix all conflicts in the graphs.
-    static void resolveConflicts(AVarBoundsInfo *BI);
+    void resolveConflicts(AVarBoundsInfo *BI);
 };
 
 #endif // LLVM_CLANG_3C_AVARBOUNDSCONFLICTRESOLVER_H

--- a/clang/include/clang/3C/AVarBoundsConflictResolver.h
+++ b/clang/include/clang/3C/AVarBoundsConflictResolver.h
@@ -19,12 +19,12 @@
 class AVarBoundsConflictResolver {
 public:
     // Fill WorkList with conflicting bounds. This list will be later used to
-    // propogate the conflicts.
+    // propagate the conflicts.
     void seedInitialWorkList(AVarBoundsInfo *BI,
                              AVarGraph &BKGraph,
                              std::set<BoundsKey> &WorkList);
     
-    // Using the WorkList, propogate the conflicts to all conncted Nodes in the graph
+    // Using the WorkList, propagate the conflicts to all conncted Nodes in the graph
     void propogateConflicts(const BoundsKey &N,
                             AVarBoundsInfo *BI,
                             AVarGraph &BKGraph,

--- a/clang/include/clang/3C/AVarBoundsConflictResolver.h
+++ b/clang/include/clang/3C/AVarBoundsConflictResolver.h
@@ -31,8 +31,7 @@ public:
                             std::set<BoundsKey> &WorkList);
     
     // Fix all conflicts in the graphs.
-    void resolveConflicts(AVarBoundsInfo *BI,
-                          std::set<BoundsKey> &WorkList);
+    void resolveConflicts(AVarBoundsInfo *BI);
 };
 
 #endif // LLVM_CLANG_3C_AVARBOUNDSCONFLICTRESOLVER_H

--- a/clang/include/clang/3C/AVarBoundsInfo.h
+++ b/clang/include/clang/3C/AVarBoundsInfo.h
@@ -297,7 +297,8 @@ public:
   bool isInAccessibleScope(BoundsKey From, BoundsKey To);
 
   // Propagate the array bounds information for all array ptrs.
-  void performFlowAnalysis(ProgramInfo *PI, bool ResolveConflits = false);
+  void performFlowAnalysis(ProgramInfo *PI, std::set<BoundsKey> &ConflictingNodes,
+                           bool RunResolver = false);
 
   // Get the context sensitive BoundsKey for the given key at CallSite
   // located at PSL.

--- a/clang/include/clang/3C/AVarBoundsInfo.h
+++ b/clang/include/clang/3C/AVarBoundsInfo.h
@@ -191,6 +191,8 @@ public:
     TmpBoundsKey.clear();
     ArrPointersWithArithmetic.clear();
   }
+
+  // Clear all bounds related stats.
   void clear();
 
   typedef std::tuple<std::string, std::string, bool, unsigned> ParamDeclType;
@@ -220,7 +222,7 @@ public:
   // Insert the variable into the system.
   void insertVariable(clang::Decl *D);
 
-  // Make a BoundsKey as invalid.
+  // Mark a BoundsKey as invalid.
   void insertInToImpossibleBounds(BoundsKey BK) { PointersWithImpossibleBounds.insert(BK); }
 
   // Get variable helpers. These functions will fatal fail if the provided
@@ -234,10 +236,13 @@ public:
   // Generate a random bounds key to be used for inference.
   BoundsKey getRandomBKey();
 
+  // Returns a reference to the ProgVarGraph graph.
   AVarGraph &getProgVarGraph() { return ProgVarGraph; }
 
+  // Returns a reference to the CtxSensProgVarGraph graph.
   AVarGraph &getCtxSensProgVarGraph() { return CtxSensProgVarGraph; }
 
+  // Returns a reference to the RevCtxSensProgVarGraph graph.
   AVarGraph &getRevCtxSensProgVarGraph() { return RevCtxSensProgVarGraph; }
 
   // Add Assignments between variables. These methods will add edges between

--- a/clang/include/clang/3C/AVarBoundsInfo.h
+++ b/clang/include/clang/3C/AVarBoundsInfo.h
@@ -450,6 +450,10 @@ private:
   // Get all the array pointers that need bounds.
   void getBoundsNeededArrPointers(std::set<BoundsKey> &AB) const;
 
+  // Remove bounds conflits by walking though all graphs
+  // and marking nodes with conflicting bounds as unknown.
+  void removeConflicts();
+
   // Keep only highest priority bounds for all the provided BoundsKeys
   // returns true if any thing changed, else false.
   bool keepHighestPriorityBounds();

--- a/clang/include/clang/3C/AVarBoundsInfo.h
+++ b/clang/include/clang/3C/AVarBoundsInfo.h
@@ -231,6 +231,12 @@ public:
   // Generate a random bounds key to be used for inference.
   BoundsKey getRandomBKey();
 
+  AVarGraph &getProgVarGraph(){ return ProgVarGraph; }
+
+  AVarGraph &getCtxSensProgVarGraph(){ return CtxSensProgVarGraph; }
+
+  AVarGraph &getRevCtxSensProgVarGraph(){ return RevCtxSensProgVarGraph; }
+
   // Add Assignments between variables. These methods will add edges between
   // corresponding BoundsKeys
   bool addAssignment(BoundsKey L, BoundsKey R);
@@ -449,10 +455,6 @@ private:
 
   // Get all the array pointers that need bounds.
   void getBoundsNeededArrPointers(std::set<BoundsKey> &AB) const;
-
-  // Remove bounds conflits by walking though all graphs
-  // and marking nodes with conflicting bounds as unknown.
-  void removeConflicts();
 
   // Keep only highest priority bounds for all the provided BoundsKeys
   // returns true if any thing changed, else false.

--- a/clang/include/clang/3C/AVarBoundsInfo.h
+++ b/clang/include/clang/3C/AVarBoundsInfo.h
@@ -297,8 +297,7 @@ public:
   bool isInAccessibleScope(BoundsKey From, BoundsKey To);
 
   // Propagate the array bounds information for all array ptrs.
-  void performFlowAnalysis(ProgramInfo *PI, std::set<BoundsKey> &ConflictingNodes,
-                           bool RunResolver = false);
+  void performFlowAnalysis(ProgramInfo *PI, bool ResolveConflits = false);
 
   // Get the context sensitive BoundsKey for the given key at CallSite
   // located at PSL.

--- a/clang/include/clang/3C/AVarBoundsInfo.h
+++ b/clang/include/clang/3C/AVarBoundsInfo.h
@@ -220,6 +220,9 @@ public:
   // Insert the variable into the system.
   void insertVariable(clang::Decl *D);
 
+  // Make a BoundsKey as invalid
+  void insertInToImpossibleBounds(BoundsKey BK) { PointersWithImpossibleBounds.insert(BK); }
+
   // Get variable helpers. These functions will fatal fail if the provided
   // Decl cannot have a BoundsKey
   BoundsKey getVariable(clang::VarDecl *VD);
@@ -231,11 +234,11 @@ public:
   // Generate a random bounds key to be used for inference.
   BoundsKey getRandomBKey();
 
-  AVarGraph &getProgVarGraph(){ return ProgVarGraph; }
+  AVarGraph &getProgVarGraph() { return ProgVarGraph; }
 
-  AVarGraph &getCtxSensProgVarGraph(){ return CtxSensProgVarGraph; }
+  AVarGraph &getCtxSensProgVarGraph() { return CtxSensProgVarGraph; }
 
-  AVarGraph &getRevCtxSensProgVarGraph(){ return RevCtxSensProgVarGraph; }
+  AVarGraph &getRevCtxSensProgVarGraph() { return RevCtxSensProgVarGraph; }
 
   // Add Assignments between variables. These methods will add edges between
   // corresponding BoundsKeys
@@ -294,7 +297,7 @@ public:
   bool isInAccessibleScope(BoundsKey From, BoundsKey To);
 
   // Propagate the array bounds information for all array ptrs.
-  void performFlowAnalysis(ProgramInfo *PI);
+  void performFlowAnalysis(ProgramInfo *PI, bool ResolveConflits = false);
 
   // Get the context sensitive BoundsKey for the given key at CallSite
   // located at PSL.
@@ -393,8 +396,8 @@ private:
   // BiMap of function keys and BoundsKey for function return values.
   BiMap<std::tuple<std::string, std::string, bool>, BoundsKey> FuncDeclVarMap;
 
-  PVConstraint *
-  getConstraintVariable(const ProgramInfo *PI, BoundsKey BK) const;
+  PVConstraint *getConstraintVariable(const ProgramInfo *PI,
+                                      BoundsKey BK) const;
 
   // Graph of all program variables.
   AVarGraph ProgVarGraph;

--- a/clang/include/clang/3C/AVarBoundsInfo.h
+++ b/clang/include/clang/3C/AVarBoundsInfo.h
@@ -336,7 +336,7 @@ private:
 
   friend struct llvm::DOTGraphTraits<AVarGraph>;
   // List of bounds priority in descending order of priorities.
-  static std::vector<BoundsPriority> PrioList;
+  const static std::vector<BoundsPriority> PrioList;
 
   // Variable that is used to generate new bound keys.
   BoundsKey BCount;

--- a/clang/include/clang/3C/AVarBoundsInfo.h
+++ b/clang/include/clang/3C/AVarBoundsInfo.h
@@ -220,7 +220,7 @@ public:
   // Insert the variable into the system.
   void insertVariable(clang::Decl *D);
 
-  // Make a BoundsKey as invalid
+  // Make a BoundsKey as invalid.
   void insertInToImpossibleBounds(BoundsKey BK) { PointersWithImpossibleBounds.insert(BK); }
 
   // Get variable helpers. These functions will fatal fail if the provided
@@ -297,7 +297,7 @@ public:
   bool isInAccessibleScope(BoundsKey From, BoundsKey To);
 
   // Propagate the array bounds information for all array ptrs.
-  void performFlowAnalysis(ProgramInfo *PI, bool ResolveConflits = false);
+  void performFlowAnalysis(ProgramInfo *PI, bool ResolveConflicts = false);
 
   // Get the context sensitive BoundsKey for the given key at CallSite
   // located at PSL.

--- a/clang/include/clang/3C/AVarBoundsInfo.h
+++ b/clang/include/clang/3C/AVarBoundsInfo.h
@@ -191,6 +191,7 @@ public:
     TmpBoundsKey.clear();
     ArrPointersWithArithmetic.clear();
   }
+  void clear();
 
   typedef std::tuple<std::string, std::string, bool, unsigned> ParamDeclType;
 

--- a/clang/include/clang/3C/Constraints.h
+++ b/clang/include/clang/3C/Constraints.h
@@ -505,6 +505,7 @@ public:
   const ConstraintsGraph &getPtrTypCG() const;
 
   void resetEnvironment();
+  void clear();
   bool checkInitialEnvSanity();
 
   // Remove all constraints that were generated because of the

--- a/clang/include/clang/3C/ConstraintsGraph.h
+++ b/clang/include/clang/3C/ConstraintsGraph.h
@@ -208,10 +208,6 @@ public:
     return getNeighbors(D, DataSet, false, Append);
   }
 
-  auto getNodes(){
-    return NodeSet;
-  }
-  
   NodeType *findNode(Data D) const {
     if (NodeSet.find(D) != NodeSet.end())
       return NodeSet.at(D);

--- a/clang/include/clang/3C/ConstraintsGraph.h
+++ b/clang/include/clang/3C/ConstraintsGraph.h
@@ -208,6 +208,10 @@ public:
     return getNeighbors(D, DataSet, false, Append);
   }
 
+  auto getNodes(){
+    return NodeSet;
+  }
+  
   NodeType *findNode(Data D) const {
     if (NodeSet.find(D) != NodeSet.end())
       return NodeSet.at(D);

--- a/clang/include/clang/3C/MultiDecls.h
+++ b/clang/include/clang/3C/MultiDecls.h
@@ -211,6 +211,7 @@ public:
   MultiDeclInfo *findContainingMultiDecl(MultiDeclMemberDecl *MMD);
   MultiDeclInfo *findContainingMultiDecl(TagDecl *TD);
   bool wasBaseTypeRenamed(Decl *D);
+  void clear();
 };
 
 #endif // LLVM_CLANG_3C_MULTIDECLS_H

--- a/clang/include/clang/3C/ProgramInfo.h
+++ b/clang/include/clang/3C/ProgramInfo.h
@@ -83,6 +83,7 @@ public:
   typedef std::map<std::string, ExternalFunctionMapType> StaticFunctionMapType;
 
   ProgramInfo();
+  virtual ~ProgramInfo();
   void clear();
   void print(llvm::raw_ostream &O) const;
   void dump() const { print(llvm::errs()); }

--- a/clang/include/clang/3C/ProgramInfo.h
+++ b/clang/include/clang/3C/ProgramInfo.h
@@ -229,8 +229,6 @@ private:
   Constraints CS;
   // Is the ProgramInfo persisted? Only tested in asserts. Starts at true.
   bool Persisted;
-  std::mutex clearCState;
-
 
   // Map of global decls for which we don't have a definition, the keys are
   // names of external vars, the value is whether the def

--- a/clang/include/clang/3C/ProgramInfo.h
+++ b/clang/include/clang/3C/ProgramInfo.h
@@ -83,6 +83,7 @@ public:
   typedef std::map<std::string, ExternalFunctionMapType> StaticFunctionMapType;
 
   ProgramInfo();
+  void clear();
   void print(llvm::raw_ostream &O) const;
   void dump() const { print(llvm::errs()); }
   void dumpJson(llvm::raw_ostream &O) const;
@@ -227,6 +228,8 @@ private:
   Constraints CS;
   // Is the ProgramInfo persisted? Only tested in asserts. Starts at true.
   bool Persisted;
+  std::mutex clearCState;
+
 
   // Map of global decls for which we don't have a definition, the keys are
   // names of external vars, the value is whether the def

--- a/clang/include/clang/3C/Utils.h
+++ b/clang/include/clang/3C/Utils.h
@@ -189,7 +189,12 @@ std::string getSourceText(const clang::SourceRange &SR,
 std::string getSourceText(const clang::CharSourceRange &SR,
                           const clang::ASTContext &C);
 
-// Find the longest common subsequence.
+// Find the longest common subsequence of two strings.
+// This is used to find the longest common subsequence of two variable names.
+// @param Str1 The name of the first variable.
+// @param Str2 The name of the second variable.
+// @param Str1Len The length of the first variable name.
+// @param Str2Len The length of the second variable name.
 unsigned longestCommonSubsequence(const char *Str1, const char *Str2,
                                   unsigned long Str1Len, unsigned long Str2Len);
 

--- a/clang/lib/3C/3C.cpp
+++ b/clang/lib/3C/3C.cpp
@@ -591,10 +591,6 @@ bool _3CInterface::solveConstraints() {
   if (_3COpts.DumpIntermediate)
     dumpConstraintOutputJson(FINAL_OUTPUT_SUFFIX, *GlobalProgramInfo);
 
-  // Set of Nodes that are conflicting
-  std::set<BoundsKey> BeforeAllocator;
-  std::set<BoundsKey> AfterAllocator;
-  std::set<BoundsKey> FinalConflictingNodes;
 
   if (_3COpts.AllTypes) {
     // Add declared bounds for all constant sized arrays. This needs to happen
@@ -614,7 +610,7 @@ bool _3CInterface::solveConstraints() {
 
     // Propagate initial data-flow information for Array pointers from
     // bounds declarations.
-    GlobalProgramInfo->getABoundsInfo().performFlowAnalysis(*&GlobalProgramInfo, BeforeAllocator, true);
+    GlobalProgramInfo->getABoundsInfo().performFlowAnalysis(*&GlobalProgramInfo);
 
     // 4. Infer the bounds based on calls to malloc and calloc
     AllocBasedBoundsInference ABBI =
@@ -625,7 +621,7 @@ bool _3CInterface::solveConstraints() {
       return false;
 
     // Propagate the information from allocator bounds.
-    GlobalProgramInfo->getABoundsInfo().performFlowAnalysis(*&GlobalProgramInfo, AfterAllocator, true);
+    GlobalProgramInfo->getABoundsInfo().performFlowAnalysis(*&GlobalProgramInfo);
   }
 
   // 5. Run intermediate tool hook to run visitors that need to be executed
@@ -637,13 +633,9 @@ bool _3CInterface::solveConstraints() {
     return false;
 
   if (_3COpts.AllTypes) {
-    // We will make all nodes common to both the sets as Impossible
-    std::set_intersection(BeforeAllocator.begin(), BeforeAllocator.end(),
-                          AfterAllocator.begin(), AfterAllocator.end(),
-                          std::inserter(FinalConflictingNodes, FinalConflictingNodes.begin()));
 
     // Propagate data-flow information for Array pointers.
-    GlobalProgramInfo->getABoundsInfo().performFlowAnalysis(*&GlobalProgramInfo, FinalConflictingNodes);
+    GlobalProgramInfo->getABoundsInfo().performFlowAnalysis(*&GlobalProgramInfo, true);
 
     /*if (DebugArrSolver)
       GlobalProgramInfo->getABoundsInfo().dumpAVarGraph(

--- a/clang/lib/3C/3C.cpp
+++ b/clang/lib/3C/3C.cpp
@@ -342,7 +342,6 @@ _3CInterface::create(const struct _3COptions &CCopt,
   // NOLINTNEXTLINE(readability-identifier-naming)
   std::unique_ptr<_3CInterface> _3CInter(
       new _3CInterface(CCopt, SourceFileList, CompDB));
-  
   if (_3CInter->ConstructionFailed) {
     return nullptr;
   }

--- a/clang/lib/3C/3C.cpp
+++ b/clang/lib/3C/3C.cpp
@@ -584,7 +584,7 @@ bool _3CInterface::solveConstraints() {
     errs() << "Constraints solved\n";
 
   if (_3COpts.WarnRootCause) {
-    assert(CStateisclear=true);
+    assert(CStateisclear == true);
     GlobalProgramInfo->computeInterimConstraintState(FilePaths);
   }
 
@@ -695,7 +695,7 @@ bool _3CInterface::dumpStats() {
 
   if (_3COpts.DumpStats) {
     GlobalProgramInfo->printStats(FilePaths, llvm::errs(), true);
-    assert(CStateisclear=true);
+    assert(CStateisclear == true);
     GlobalProgramInfo->computeInterimConstraintState(FilePaths);
     std::error_code Ec;
     llvm::raw_fd_ostream OutputJson(_3COpts.StatsOutputJson, Ec);
@@ -778,7 +778,7 @@ bool _3CInterface::makeSinglePtrNonWild(ConstraintKey TargetPtr) {
   runSolver(*GlobalProgramInfo, FilePaths);
 
   // Compute new disjoint set.
-  assert(CStateisclear=true);
+  assert(CStateisclear == true);
   GlobalProgramInfo->computeInterimConstraintState(FilePaths);
 
   // Get new WILD pointers.
@@ -816,7 +816,7 @@ bool _3CInterface::invalidateWildReasonGlobally(ConstraintKey PtrKey) {
   runSolver(*GlobalProgramInfo, FilePaths);
 
   // Recompute the WILD pointer disjoint sets.
-  assert(CStateisclear=true);
+  assert(CStateisclear == true);
   GlobalProgramInfo->computeInterimConstraintState(FilePaths);
 
   // Computed the number of removed pointers.

--- a/clang/lib/3C/3C.cpp
+++ b/clang/lib/3C/3C.cpp
@@ -580,6 +580,7 @@ bool _3CInterface::solveConstraints() {
     errs() << "Constraints solved\n";
 
   if (_3COpts.WarnRootCause)
+    assert(CStateisclear=true);
     GlobalProgramInfo.computeInterimConstraintState(FilePaths);
 
   if (_3COpts.DumpIntermediate)
@@ -687,6 +688,7 @@ bool _3CInterface::dumpStats() {
 
   if (_3COpts.DumpStats) {
     GlobalProgramInfo.printStats(FilePaths, llvm::errs(), true);
+    assert(CStateisclear=true);
     GlobalProgramInfo.computeInterimConstraintState(FilePaths);
     std::error_code Ec;
     llvm::raw_fd_ostream OutputJson(_3COpts.StatsOutputJson, Ec);
@@ -769,6 +771,7 @@ bool _3CInterface::makeSinglePtrNonWild(ConstraintKey TargetPtr) {
   runSolver(GlobalProgramInfo, FilePaths);
 
   // Compute new disjoint set.
+  assert(CStateisclear=true);
   GlobalProgramInfo.computeInterimConstraintState(FilePaths);
 
   // Get new WILD pointers.
@@ -805,7 +808,8 @@ bool _3CInterface::invalidateWildReasonGlobally(ConstraintKey PtrKey) {
   runSolver(GlobalProgramInfo, FilePaths);
 
   // Recompute the WILD pointer disjoint sets.
-  GlobalProgramInfo.computeInterimConstraintState(FilePaths);
+  assert(CStateisclear=true);
+    GlobalProgramInfo.computeInterimConstraintState(FilePaths);
 
   // Computed the number of removed pointers.
   CVars &NewWildPtrs = PtrDisjointSet.AllWildAtoms;
@@ -815,6 +819,11 @@ bool _3CInterface::invalidateWildReasonGlobally(ConstraintKey PtrKey) {
                       std::inserter(RemovePtrs, RemovePtrs.begin()));
 
   return !RemovePtrs.empty();
+}
+
+void _3CInterface::resetInterface() {
+  GlobalProgramInfo.clear();
+  ASTs.clear();
 }
 
 

--- a/clang/lib/3C/3C.cpp
+++ b/clang/lib/3C/3C.cpp
@@ -750,6 +750,7 @@ void _3CInterface::invalidateAllConstraintsWithReason(
     delete (ToDelCons);
   }
 }
+
 bool _3CInterface::makeSinglePtrNonWild(ConstraintKey TargetPtr) {
   std::lock_guard<std::mutex> Lock(InterfaceMutex);
   CVars RemovePtrs;
@@ -761,14 +762,13 @@ bool _3CInterface::makeSinglePtrNonWild(ConstraintKey TargetPtr) {
   CVars OldWildPtrs = PtrDisjointSet.AllWildAtoms;
 
   //Delete the constraint that makes the target non-wild
+  VarAtom *VA = CS.getOrCreateVar(TargetPtr, "q", VarAtom::V_Other);
+  Geq NewE(VA, CS.getWild(), ReasonLoc());
+  Constraint *OriginalConstraint = *CS.getConstraints().find(&NewE);
+  CS.removeConstraint(OriginalConstraint);
+  VA->getAllConstraints().erase(OriginalConstraint);
 
-  VarAtom *VA = CS.getOrCreateVar(TargetPtr,"q",VarAtom::V_Other);
-  Geq newE(VA, CS.getWild(),ReasonLoc());
-  Constraint *originalConstraint = *CS.getConstraints().find(&newE);
-  CS.removeConstraint(originalConstraint);
-  VA->getAllConstraints().erase(originalConstraint);
-
-  delete(originalConstraint);
+  delete(OriginalConstraint);
 
   // Reset the constraint system.
   CS.resetEnvironment();
@@ -791,6 +791,7 @@ bool _3CInterface::makeSinglePtrNonWild(ConstraintKey TargetPtr) {
 
   return !RemovePtrs.empty();
 }
+
 bool _3CInterface::invalidateWildReasonGlobally(ConstraintKey PtrKey) {
   std::lock_guard<std::mutex> Lock(InterfaceMutex);
 
@@ -804,7 +805,7 @@ bool _3CInterface::invalidateWildReasonGlobally(ConstraintKey PtrKey) {
 
   // Delete ALL the constraints that have the same given reason.
   VarAtom *VA = CS.getOrCreateVar(PtrKey, "q", VarAtom::V_Other);
-  Geq NewE(VA, CS.getWild(),ReasonLoc());
+  Geq NewE(VA, CS.getWild(), ReasonLoc());
   Constraint *OriginalConstraint = *CS.getConstraints().find(&NewE);
   invalidateAllConstraintsWithReason(OriginalConstraint);
 
@@ -816,7 +817,7 @@ bool _3CInterface::invalidateWildReasonGlobally(ConstraintKey PtrKey) {
 
   // Recompute the WILD pointer disjoint sets.
   assert(CStateisclear=true);
-    GlobalProgramInfo->computeInterimConstraintState(FilePaths);
+  GlobalProgramInfo->computeInterimConstraintState(FilePaths);
 
   // Computed the number of removed pointers.
   CVars &NewWildPtrs = PtrDisjointSet.AllWildAtoms;

--- a/clang/lib/3C/3C.cpp
+++ b/clang/lib/3C/3C.cpp
@@ -583,9 +583,10 @@ bool _3CInterface::solveConstraints() {
   if (_3COpts.Verbose)
     errs() << "Constraints solved\n";
 
-  if (_3COpts.WarnRootCause)
+  if (_3COpts.WarnRootCause) {
     assert(CStateisclear=true);
     GlobalProgramInfo->computeInterimConstraintState(FilePaths);
+  }
 
   if (_3COpts.DumpIntermediate)
     dumpConstraintOutputJson(FINAL_OUTPUT_SUFFIX, *GlobalProgramInfo);
@@ -632,7 +633,7 @@ bool _3CInterface::solveConstraints() {
 
   if (_3COpts.AllTypes) {
     // Propagate data-flow information for Array pointers.
-    GlobalProgramInfo->getABoundsInfo().performFlowAnalysis(*&GlobalProgramInfo);
+    GlobalProgramInfo->getABoundsInfo().performFlowAnalysis(*&GlobalProgramInfo, true);
 
     /*if (DebugArrSolver)
       GlobalProgramInfo->getABoundsInfo().dumpAVarGraph(
@@ -829,8 +830,6 @@ void _3CInterface::resetInterface() {
   if(GlobalProgramInfo)
     delete (GlobalProgramInfo);
   GlobalProgramInfo = new ProgramInfo();
-  //GlobalProgramInfo->clear();
-  ASTs.clear();
 }
 
 

--- a/clang/lib/3C/3C.cpp
+++ b/clang/lib/3C/3C.cpp
@@ -744,7 +744,7 @@ void _3CInterface::invalidateAllConstraintsWithReason(
     assert(dyn_cast<Geq>(ToDelCons) && "We can only delete Geq constraints.");
     Geq *TCons = dyn_cast<Geq>(ToDelCons);
     auto *Vatom = dyn_cast<VarAtom>(TCons->getLHS());
-    assert(Vatom != nullptr && "Equality constraint with out VarAtom as LHS");
+    assert(Vatom != nullptr && "Equality constraint without VarAtom as LHS");
     VarAtom *VS = CS.getOrCreateVar(Vatom->getLoc(), "q", VarAtom::V_Other);
     VS->getAllConstraints().erase(TCons);
     delete (ToDelCons);
@@ -761,7 +761,7 @@ bool _3CInterface::makeSinglePtrNonWild(ConstraintKey TargetPtr) {
 
   CVars OldWildPtrs = PtrDisjointSet.AllWildAtoms;
 
-  //Delete the constraint that makes the target non-wild
+  // Delete the constraint that makes the target non-wild
   VarAtom *VA = CS.getOrCreateVar(TargetPtr, "q", VarAtom::V_Other);
   Geq NewE(VA, CS.getWild(), ReasonLoc());
   Constraint *OriginalConstraint = *CS.getConstraints().find(&NewE);
@@ -774,7 +774,6 @@ bool _3CInterface::makeSinglePtrNonWild(ConstraintKey TargetPtr) {
   CS.resetEnvironment();
 
   // Solve the constraints.
-  //assert (CS == GlobalProgramInfo->getConstraints());
   runSolver(*GlobalProgramInfo, FilePaths);
 
   // Compute new disjoint set.

--- a/clang/lib/3C/ABounds.cpp
+++ b/clang/lib/3C/ABounds.cpp
@@ -110,6 +110,8 @@ bool CountPlusOneBound::areSame(ABounds *O, AVarBoundsInfo *ABI) {
   return false;
 }
 
+ABounds *CountPlusOneBound::makeCopy(BoundsKey NK) { return new CountPlusOneBound(NK); }
+
 std::string ByteBound::mkStringWithLowerBound(AVarBoundsInfo *ABI,
                                               clang::Decl *D) {
   std::string LowerBound = ABounds::getBoundsKeyStr(LowerBoundKey, ABI, D);

--- a/clang/lib/3C/AVarBoundsConflictResolver.cpp
+++ b/clang/lib/3C/AVarBoundsConflictResolver.cpp
@@ -21,7 +21,7 @@ void AVarBoundsConflictResolver::seedInitialWorkList(AVarBoundsInfo *BI,
 
   // Utility to check if atleast one neighbour of a node
   // is having same BoundsKind.
-  auto IsSameKind = [&BI, &BKGraph](BoundsKey K, ABounds *KAB) {
+  auto HasSameKindNeighbour = [&BI, &BKGraph](BoundsKey K, ABounds *KAB) {
     std::set<BoundsKey> PredKeys;
     BKGraph.getPredecessors(K, PredKeys);
     for (auto &N : PredKeys) {
@@ -37,7 +37,7 @@ void AVarBoundsConflictResolver::seedInitialWorkList(AVarBoundsInfo *BI,
     ABounds *OldABounds = BI->getBounds(Curr, BoundsPriority::FlowInferred);
     if (OldABounds) {
       // Make sure atleast one neighbour is having same BoundsKind.
-      if (!IsSameKind(Curr, OldABounds))
+      if (!HasSameKindNeighbour(Curr, OldABounds))
         continue;
 
       OldABounds = OldABounds->makeCopy(OldABounds->getLengthKey());

--- a/clang/lib/3C/AVarBoundsConflictResolver.cpp
+++ b/clang/lib/3C/AVarBoundsConflictResolver.cpp
@@ -37,6 +37,7 @@ void AVarBoundsConflictResolver::seedInitialWorkList(AVarBoundsInfo *BI,
       // then we add the node to WorkList and to ImpossibleBounds.
       if (!NewABounds->areSame(OldABounds, BI)) {
         WorkList.insert(Curr);
+        BI->insertInToImpossibleBounds(Curr);
         BI->removeBounds(Curr, BoundsPriority::FlowInferred);
       }
       delete OldABounds;
@@ -63,6 +64,7 @@ void AVarBoundsConflictResolver::propogateConflicts(const BoundsKey &N,
       ABounds *NewABounds = BI->getBounds(S, BoundsPriority::FlowInferred);
       if (!NewABounds || !NewABounds->areSame(OldABounds, BI)) {
         WorkList.insert(S);
+        BI->insertInToImpossibleBounds(S);
       }
       
       delete OldABounds;
@@ -70,13 +72,13 @@ void AVarBoundsConflictResolver::propogateConflicts(const BoundsKey &N,
   }
 }
 
-void AVarBoundsConflictResolver::resolveConflicts(AVarBoundsInfo *BI,
-                                                  std::set<BoundsKey> &WorkList) {
+void AVarBoundsConflictResolver::resolveConflicts(AVarBoundsInfo *BI) {
+  std::set<BoundsKey> WorkList;
   std::set<BoundsKey> OldWorkList;
   
   // Find initial conflicts from ProgVarGraph and add it to WorkList
   seedInitialWorkList(BI, BI->getProgVarGraph(), WorkList);
-
+  
   bool WorkListChanged = WorkList != OldWorkList;
   OldWorkList = WorkList;
   while (WorkListChanged) {

--- a/clang/lib/3C/AVarBoundsConflictResolver.cpp
+++ b/clang/lib/3C/AVarBoundsConflictResolver.cpp
@@ -28,7 +28,7 @@ void AVarBoundsConflictResolver::seedInitialWorkList(AVarBoundsInfo *BI,
       ABI.convergeInferredBounds();
       ABI.clearInferredBounds();
       ABounds *NewABounds = BI->getBounds(Curr, BoundsPriority::FlowInferred);
-      //If we were not able to predict new bounds, put back the old bounds
+      // If we were not able to predict new bounds, put back the old bounds.
       if (!NewABounds) {
         BI->mergeBounds(Curr, BoundsPriority::FlowInferred, OldABounds);
         continue;

--- a/clang/lib/3C/AVarBoundsConflictResolver.cpp
+++ b/clang/lib/3C/AVarBoundsConflictResolver.cpp
@@ -12,15 +12,16 @@
 
 #include "clang/3C/AVarBoundsConflictResolver.h"
 
-void AVarBoundsConflictResolver::seedInitialWorkList(AVarBoundsInfo *BI, AVarGraph &BKGraph,
-                                                     std::set<BoundsKey> &WorkList){
+void AVarBoundsConflictResolver::seedInitialWorkList(AVarBoundsInfo *BI,
+                                                     AVarGraph &BKGraph,
+                                                     std::set<BoundsKey> &WorkList) {
   AvarBoundsInference ABI(BI);
   // Make sure previous inference does not interfere.
   ABI.clearInferredBounds();
-  for(auto *Node = BKGraph.begin(); Node!= BKGraph.end(); Node++){
+  for (auto *Node = BKGraph.begin(); Node != BKGraph.end(); Node++) {
     BoundsKey Curr =  (*Node)->getData();
     ABounds *OldABounds = BI->getBounds(Curr, BoundsPriority::FlowInferred);
-    if(OldABounds){
+    if (OldABounds) {
       OldABounds = OldABounds->makeCopy(OldABounds->getLengthKey());
       BI->removeBounds(Curr, BoundsPriority::FlowInferred);
       ABI.inferBounds(Curr, BKGraph, false);
@@ -30,14 +31,9 @@ void AVarBoundsConflictResolver::seedInitialWorkList(AVarBoundsInfo *BI, AVarGra
       // If the node does not have FlowInferred bounds or
       // it has a bounds which is different from the previous one,
       // then we add the node to WorkList.
-      if(!NewABounds || !NewABounds->areSame(OldABounds, BI)){
+      if (!NewABounds || !NewABounds->areSame(OldABounds, BI)) {
         WorkList.insert(Curr);
-        // If we got conflicting bounds, we don't want to keep it
-        // since we assume this node's bounds is unknown when we add it to
-        // the WorkList. 
-        // TODO:
-        //  Verify if this is correct method.
-        if(NewABounds)
+        if (NewABounds)
           BI->removeBounds(Curr, BoundsPriority::FlowInferred);
       }
       delete OldABounds;
@@ -45,45 +41,43 @@ void AVarBoundsConflictResolver::seedInitialWorkList(AVarBoundsInfo *BI, AVarGra
   }
 }
 
-void AVarBoundsConflictResolver::propogateConflicts(const BoundsKey &N, AVarBoundsInfo *BI,
-                                                    AVarGraph &BKGraph, std::set<BoundsKey> &WorkList){
+void AVarBoundsConflictResolver::propogateConflicts(const BoundsKey &N,
+                                                    AVarBoundsInfo *BI,
+                                                    AVarGraph &BKGraph,
+                                                    std::set<BoundsKey> &WorkList) {
   std::set<BoundsKey> SuccKeys;
   AvarBoundsInference ABI(BI);
   BKGraph.getSuccessors(N, SuccKeys);
   ABI.clearInferredBounds();
-  for(auto &S: SuccKeys){
+  for (auto &S : SuccKeys) {
     ABounds *OldABounds = BI->getBounds(S, BoundsPriority::FlowInferred);
-    if(OldABounds){
+    if (OldABounds) {
       OldABounds = OldABounds->makeCopy(OldABounds->getLengthKey());
       BI->removeBounds(S, BoundsPriority::FlowInferred);
       ABI.inferBounds(S, BKGraph, false);
       ABI.convergeInferredBounds();
       ABI.clearInferredBounds();
       ABounds *NewABounds = BI->getBounds(S, BoundsPriority::FlowInferred);
-      if(!NewABounds || !NewABounds->areSame(OldABounds, BI)){
+      if (!NewABounds || !NewABounds->areSame(OldABounds, BI))
         WorkList.insert(S);
-      }
+      
       delete OldABounds;
     }
   }
 }
 
-void AVarBoundsConflictResolver::resolveConflicts(AVarBoundsInfo *BI){
+void AVarBoundsConflictResolver::resolveConflicts(AVarBoundsInfo *BI) {
   std::set<BoundsKey> WorkList;
   std::set<BoundsKey> OldWorkList;
   
   // Find initial conflicts from ProgVarGraph and add it to WorkList
   seedInitialWorkList(BI, BI->getProgVarGraph(), WorkList);
-  // Find initial conflicts from CtxSensProgVarGraph and add it to WorkList
-  // seedInitialWorkList(BI, BI->getCtxSensProgVarGraph(), WorkList);
-  // Find initial conflicts from RevCtxSensProgVarGraph and add it to WorkList
-  // seedInitialWorkList(BI, BI->getRevCtxSensProgVarGraph(), WorkList);
   
   bool WorkListChanged = WorkList != OldWorkList;
   OldWorkList = WorkList;
 
-  while(WorkListChanged){
-    for(auto &N: OldWorkList){
+  while (WorkListChanged) {
+    for (auto &N : OldWorkList) {
       // Propogate conflicts in ProgVarGraph
       propogateConflicts(N, BI, BI->getProgVarGraph(), WorkList);
       // Propogate conflicts in CtxSensProgVarGraph

--- a/clang/lib/3C/AVarBoundsConflictResolver.cpp
+++ b/clang/lib/3C/AVarBoundsConflictResolver.cpp
@@ -1,0 +1,97 @@
+//=--AvarBoundsConflictResolver.cpp-------------------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Implementation of methods in AVarBoundsConflictResolver.h.
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/3C/AVarBoundsConflictResolver.h"
+
+void AVarBoundsConflictResolver::seedInitialWorkList(AVarBoundsInfo *BI, AVarGraph &BKGraph,
+                                                     std::set<BoundsKey> &WorkList){
+  AvarBoundsInference ABI(BI);
+  // Make sure previous inference does not interfere.
+  ABI.clearInferredBounds();
+  for(auto *Node = BKGraph.begin(); Node!= BKGraph.end(); Node++){
+    BoundsKey Curr =  (*Node)->getData();
+    ABounds *OldABounds = BI->getBounds(Curr, BoundsPriority::FlowInferred);
+    if(OldABounds){
+      OldABounds = OldABounds->makeCopy(OldABounds->getLengthKey());
+      BI->removeBounds(Curr, BoundsPriority::FlowInferred);
+      ABI.inferBounds(Curr, BKGraph, false);
+      ABI.convergeInferredBounds();
+      ABI.clearInferredBounds();
+      ABounds *NewABounds = BI->getBounds(Curr, BoundsPriority::FlowInferred);
+      // If the node does not have FlowInferred bounds or
+      // it has a bounds which is different from the previous one,
+      // then we add the node to WorkList.
+      if(!NewABounds || !NewABounds->areSame(OldABounds, BI)){
+        WorkList.insert(Curr);
+        // If we got conflicting bounds, we don't want to keep it
+        // since we assume this node's bounds is unknown when we add it to
+        // the WorkList. 
+        // TODO:
+        //  Verify if this is correct method.
+        if(NewABounds)
+          BI->removeBounds(Curr, BoundsPriority::FlowInferred);
+      }
+      delete OldABounds;
+    }
+  }
+}
+
+void AVarBoundsConflictResolver::propogateConflicts(const BoundsKey &N, AVarBoundsInfo *BI,
+                                                    AVarGraph &BKGraph, std::set<BoundsKey> &WorkList){
+  std::set<BoundsKey> SuccKeys;
+  AvarBoundsInference ABI(BI);
+  BKGraph.getSuccessors(N, SuccKeys);
+  ABI.clearInferredBounds();
+  for(auto &S: SuccKeys){
+    ABounds *OldABounds = BI->getBounds(S, BoundsPriority::FlowInferred);
+    if(OldABounds){
+      OldABounds = OldABounds->makeCopy(OldABounds->getLengthKey());
+      BI->removeBounds(S, BoundsPriority::FlowInferred);
+      ABI.inferBounds(S, BKGraph, false);
+      ABI.convergeInferredBounds();
+      ABI.clearInferredBounds();
+      ABounds *NewABounds = BI->getBounds(S, BoundsPriority::FlowInferred);
+      if(!NewABounds || !NewABounds->areSame(OldABounds, BI)){
+        WorkList.insert(S);
+      }
+      delete OldABounds;
+    }
+  }
+}
+
+void AVarBoundsConflictResolver::resolveConflicts(AVarBoundsInfo *BI){
+  std::set<BoundsKey> WorkList;
+  std::set<BoundsKey> OldWorkList;
+  
+  // Find initial conflicts from ProgVarGraph and add it to WorkList
+  seedInitialWorkList(BI, BI->getProgVarGraph(), WorkList);
+  // Find initial conflicts from CtxSensProgVarGraph and add it to WorkList
+  // seedInitialWorkList(BI, BI->getCtxSensProgVarGraph(), WorkList);
+  // Find initial conflicts from RevCtxSensProgVarGraph and add it to WorkList
+  // seedInitialWorkList(BI, BI->getRevCtxSensProgVarGraph(), WorkList);
+  
+  bool WorkListChanged = WorkList != OldWorkList;
+  OldWorkList = WorkList;
+
+  while(WorkListChanged){
+    for(auto &N: OldWorkList){
+      // Propogate conflicts in ProgVarGraph
+      propogateConflicts(N, BI, BI->getProgVarGraph(), WorkList);
+      // Propogate conflicts in CtxSensProgVarGraph
+      propogateConflicts(N, BI, BI->getCtxSensProgVarGraph(), WorkList);
+      // Propogate conflicts in RevCtxSensProgVarGraph
+      propogateConflicts(N, BI, BI->getRevCtxSensProgVarGraph(), WorkList);
+    }
+    WorkListChanged = OldWorkList != WorkList;
+    OldWorkList = WorkList;
+  }
+}

--- a/clang/lib/3C/AVarBoundsConflictResolver.cpp
+++ b/clang/lib/3C/AVarBoundsConflictResolver.cpp
@@ -37,7 +37,6 @@ void AVarBoundsConflictResolver::seedInitialWorkList(AVarBoundsInfo *BI,
       // then we add the node to WorkList and to ImpossibleBounds.
       if (!NewABounds->areSame(OldABounds, BI)) {
         WorkList.insert(Curr);
-        BI->insertInToImpossibleBounds(Curr);
         BI->removeBounds(Curr, BoundsPriority::FlowInferred);
       }
       delete OldABounds;
@@ -64,7 +63,6 @@ void AVarBoundsConflictResolver::propogateConflicts(const BoundsKey &N,
       ABounds *NewABounds = BI->getBounds(S, BoundsPriority::FlowInferred);
       if (!NewABounds || !NewABounds->areSame(OldABounds, BI)) {
         WorkList.insert(S);
-        BI->insertInToImpossibleBounds(S);
       }
       
       delete OldABounds;
@@ -72,8 +70,8 @@ void AVarBoundsConflictResolver::propogateConflicts(const BoundsKey &N,
   }
 }
 
-void AVarBoundsConflictResolver::resolveConflicts(AVarBoundsInfo *BI) {
-  std::set<BoundsKey> WorkList;
+void AVarBoundsConflictResolver::resolveConflicts(AVarBoundsInfo *BI,
+                                                  std::set<BoundsKey> &WorkList) {
   std::set<BoundsKey> OldWorkList;
   
   // Find initial conflicts from ProgVarGraph and add it to WorkList

--- a/clang/lib/3C/AVarBoundsInfo.cpp
+++ b/clang/lib/3C/AVarBoundsInfo.cpp
@@ -17,7 +17,7 @@
 #include <sstream>
 #include <clang/3C/LowerBoundAssignment.h>
 
-std::vector<BoundsPriority> AVarBoundsInfo::PrioList{Declared, Allocator,
+const std::vector<BoundsPriority> AVarBoundsInfo::PrioList{Declared, Allocator,
                                                      FlowInferred, Heuristics};
 
 void AVarBoundsStats::print(llvm::raw_ostream &O,

--- a/clang/lib/3C/AVarBoundsInfo.cpp
+++ b/clang/lib/3C/AVarBoundsInfo.cpp
@@ -1502,6 +1502,7 @@ void AVarBoundsInfo::getBoundsNeededArrPointers(std::set<BoundsKey> &AB) const {
 void AVarBoundsInfo::performFlowAnalysis(ProgramInfo *PI) {
   auto &PStats = PI->getPerfStats();
   PStats.startArrayBoundsInferenceTime();
+  AVarBoundsConflictResolver AVarBoundsConflictResolver;
 
   // First get all the pointer vars which are ARRs. Results is stored in the
   // field ArrPointerBoundsKey. This also populates some other sets that seem to
@@ -1569,7 +1570,7 @@ void AVarBoundsInfo::performFlowAnalysis(ProgramInfo *PI) {
     OuterChanged = (TmpArrNeededBounds != ArrNeededBounds);
   }
 
-  AVarBoundsConflictResolver::resolveConflicts(this);
+  AVarBoundsConflictResolver.resolveConflicts(this);
 
   PStats.endArrayBoundsInferenceTime();
 }

--- a/clang/lib/3C/AVarBoundsInfo.cpp
+++ b/clang/lib/3C/AVarBoundsInfo.cpp
@@ -816,6 +816,28 @@ void PotentialBoundsInfo::addPotentialBoundsPOne(
   }
 }
 
+void AVarBoundsInfo::clear() {
+  BCount = 1;
+  PVarInfo.clear();
+  ConstVarKeys.clear();
+  BInfo.clear();
+  InvalidBounds.clear();
+  ArrPointersWithArithmetic.clear();
+  IneligibleForFreshLowerBound.clear();
+  PointerBoundsKey.clear();
+  ArrPointerBoundsKey.clear();
+  NtArrPointerBoundsKey.clear();
+  PointersWithImpossibleBounds.clear();
+  InProgramArrPtrBoundsKeys.clear();
+  TmpBoundsKey.clear();
+
+  DeclVarMap.clear();
+  ParamDeclVarMap.clear();
+  FuncDeclVarMap.clear();
+
+  ArrPointersWithArithmetic.clear();
+}
+
 bool AVarBoundsInfo::isValidBoundVariable(clang::Decl *D) {
   if (D == nullptr)
     return false;

--- a/clang/lib/3C/AVarBoundsInfo.cpp
+++ b/clang/lib/3C/AVarBoundsInfo.cpp
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "clang/3C/AVarBoundsConflictResolver.h"
-#include "clang/3C/AVarBoundsInfo.h"
 #include "clang/3C/3CGlobalOptions.h"
+#include "clang/3C/AVarBoundsInfo.h"
+#include "clang/3C/AVarBoundsConflictResolver.h"
 #include "clang/3C/ConstraintResolver.h"
 #include <clang/3C/LowerBoundAssignment.h>
 #include "clang/3C/ProgramInfo.h"
@@ -446,6 +446,7 @@ bool AvarBoundsInference::predictBounds(BoundsKey K,
         ABounds::BoundsKind NeighbourKind = INB.first;
         const std::set<BoundsKey> &NeighbourSet = INB.second;
         std::set<BoundsKey> NonConstSet;
+        // Find all non-const bounds of a neighbour.
         for (auto &NK : NeighbourSet) {
           auto *NKVar = this->BI->getProgramVar(NK);
           if (NKVar != nullptr && !NKVar->isNumConstant())
@@ -496,6 +497,8 @@ bool AvarBoundsInference::predictBounds(BoundsKey K,
       }
     }
 
+    // If more than 50% of neighbour of a kind is having non-const
+    // bounds, use that insted of the InferredKBnds. 
     for (auto &MB : NonConstCount) {
       if (MB.second.first > (MB.second.second / 2))
         InferredKBnds[MB.first] = InferredKNonConstBnds[MB.first];

--- a/clang/lib/3C/AVarBoundsInfo.cpp
+++ b/clang/lib/3C/AVarBoundsInfo.cpp
@@ -1506,7 +1506,7 @@ void AVarBoundsInfo::performFlowAnalysis(ProgramInfo *PI, std::set<BoundsKey> &C
 
   // Mark the set of nodes as Impossible
   if (!RunResolver) {
-    for (auto &N: ConflictingNodes)
+    for (auto &N : ConflictingNodes)
       insertInToImpossibleBounds(N);
   }
 
@@ -1575,7 +1575,7 @@ void AVarBoundsInfo::performFlowAnalysis(ProgramInfo *PI, std::set<BoundsKey> &C
     }
     OuterChanged = (TmpArrNeededBounds != ArrNeededBounds);
   }
-  
+
   if (RunResolver) {
     AVarBoundsConflictResolver AVarBoundsConflictResolver;
     AVarBoundsConflictResolver.resolveConflicts(this, ConflictingNodes);

--- a/clang/lib/3C/AVarBoundsInfo.cpp
+++ b/clang/lib/3C/AVarBoundsInfo.cpp
@@ -10,12 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "clang/3C/AVarBoundsConflictResolver.h"
 #include "clang/3C/AVarBoundsInfo.h"
 #include "clang/3C/3CGlobalOptions.h"
 #include "clang/3C/ConstraintResolver.h"
-#include "clang/3C/ProgramInfo.h"
-#include "clang/3C/AVarBoundsConflictResolver.h"
 #include <clang/3C/LowerBoundAssignment.h>
+#include "clang/3C/ProgramInfo.h"
 #include <sstream>
 
 const std::vector<BoundsPriority> AVarBoundsInfo::PrioList{Declared, Allocator,
@@ -1499,16 +1499,9 @@ void AVarBoundsInfo::getBoundsNeededArrPointers(std::set<BoundsKey> &AB) const {
 // In the above case, we use n as a potential count bounds for arr.
 // Note: we only use potential bounds for a variable when none of its
 // predecessors have bounds.
-void AVarBoundsInfo::performFlowAnalysis(ProgramInfo *PI, std::set<BoundsKey> &ConflictingNodes,
-                                         bool RunResolver) {
+void AVarBoundsInfo::performFlowAnalysis(ProgramInfo *PI, bool ResolveConflits) {
   auto &PStats = PI->getPerfStats();
   PStats.startArrayBoundsInferenceTime();
-
-  // Mark the set of nodes as Impossible
-  if (!RunResolver) {
-    for (auto &N : ConflictingNodes)
-      insertInToImpossibleBounds(N);
-  }
 
   // First get all the pointer vars which are ARRs. Results is stored in the
   // field ArrPointerBoundsKey. This also populates some other sets that seem to
@@ -1576,9 +1569,9 @@ void AVarBoundsInfo::performFlowAnalysis(ProgramInfo *PI, std::set<BoundsKey> &C
     OuterChanged = (TmpArrNeededBounds != ArrNeededBounds);
   }
 
-  if (RunResolver) {
+  if (ResolveConflits) {
     AVarBoundsConflictResolver AVarBoundsConflictResolver;
-    AVarBoundsConflictResolver.resolveConflicts(this, ConflictingNodes);
+    AVarBoundsConflictResolver.resolveConflicts(this);
   }
   PStats.endArrayBoundsInferenceTime();
 }

--- a/clang/lib/3C/AVarBoundsInfo.cpp
+++ b/clang/lib/3C/AVarBoundsInfo.cpp
@@ -1484,7 +1484,7 @@ void AVarBoundsInfo::removeConflicts(){
       auto BABounds = getBounds(B);
       // No bounds founds for PredKey
       if(!BABounds){
-        return false;
+        return true;
       }
       return AABounds->getLengthKey() == BABounds->getLengthKey() &&
            AABounds->getLowerBoundKey() == BABounds->getLowerBoundKey();

--- a/clang/lib/3C/AVarBoundsInfo.cpp
+++ b/clang/lib/3C/AVarBoundsInfo.cpp
@@ -11,11 +11,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang/3C/AVarBoundsInfo.h"
+#include "clang/3C/3CGlobalOptions.h"
 #include "clang/3C/ConstraintResolver.h"
 #include "clang/3C/ProgramInfo.h"
-#include "clang/3C/3CGlobalOptions.h"
-#include <sstream>
+#include "clang/3C/AVarBoundsConflictResolver.h"
 #include <clang/3C/LowerBoundAssignment.h>
+#include <sstream>
 
 const std::vector<BoundsPriority> AVarBoundsInfo::PrioList{Declared, Allocator,
                                                      FlowInferred, Heuristics};
@@ -1462,84 +1463,6 @@ void AVarBoundsInfo::computeArrPointers(const ProgramInfo *PI) {
     ArrPointerBoundsKey.insert(T.first);
 }
 
-void AVarBoundsInfo::removeConflicts(){
-  std::set<BoundsKey> WorkList;
-  std::set<BoundsKey> OldWorkList;
-  std::set<BoundsKey> SuccKeys;
-  bool isConflicting = false;
-  bool workListChanged = false;
-
-  // Nodes from ProgVarGraph
-  auto Nodes = this->ProgVarGraph.getNodes();
-  // Walk the ProgVarGraph, find conflicting bounds
-  // and add them to WorkList
-  for(auto &N: Nodes){
-    isConflicting = false;
-    BoundsKey Curr = N.first;
-    std::set<BoundsKey> PredKeys;
-    auto CurrABounds = getBounds(Curr, BoundsPriority::FlowInferred);
-    // Utility to check if bounds of two BoundsKey are the same
-    auto isSame = [this](BoundsKey A, BoundsKey B){
-      auto AABounds = getBounds(A, BoundsPriority::FlowInferred);
-      auto BABounds = getBounds(B);
-      // No bounds founds for PredKey
-      if(!BABounds){
-        return true;
-      }
-      return AABounds->getLengthKey() == BABounds->getLengthKey() &&
-           AABounds->getLowerBoundKey() == BABounds->getLowerBoundKey();
-    };
-    // If the bounds of Curr is FlowInferred, then check
-    // if the predecessors Bounds match with Curr's.
-    if(CurrABounds){
-      this->ProgVarGraph.getPredecessors(Curr, PredKeys);
-      for(auto &P: PredKeys){
-        if(!isSame(Curr, P)){
-          isConflicting = true;
-          removeBounds(P, BoundsPriority::FlowInferred);
-          WorkList.insert(P);
-        }
-      }
-      if(isConflicting){
-        WorkList.insert(Curr);
-        removeBounds(Curr, BoundsPriority::FlowInferred);
-      }
-    }
-  }
-  
-  workListChanged = OldWorkList != WorkList;
-  OldWorkList = WorkList;
-
-  // For every node in worklist, find the successors in all the graphs
-  // and marking them unknown and adding it to WorkList.
-  while(workListChanged){
-    for(auto &N: OldWorkList){
-      this->ProgVarGraph.getSuccessors(N, SuccKeys);
-      for(auto &Succ: SuccKeys){
-        removeBounds(Succ, BoundsPriority::FlowInferred);
-        WorkList.insert(Succ);
-      }
-      SuccKeys.clear();
-      this->CtxSensProgVarGraph.getSuccessors(N, SuccKeys);
-      for(auto &Succ: SuccKeys){
-        removeBounds(Succ, BoundsPriority::FlowInferred);
-        WorkList.insert(Succ);
-      }
-      SuccKeys.clear();
-      this->RevCtxSensProgVarGraph.getSuccessors(N, SuccKeys);
-      for(auto &Succ: SuccKeys){
-        removeBounds(Succ, BoundsPriority::FlowInferred);
-        WorkList.insert(Succ);
-      }
-      SuccKeys.clear();
-    }
-    workListChanged = OldWorkList != WorkList;
-    OldWorkList = WorkList;
-  }
-  return;
-}
-
-
 // Find the set of array pointers that need bounds. This is computed as all
 // array pointers that do not currently have a bound, have an invalid bound,
 // or have an impossible bound.
@@ -1646,7 +1569,7 @@ void AVarBoundsInfo::performFlowAnalysis(ProgramInfo *PI) {
     OuterChanged = (TmpArrNeededBounds != ArrNeededBounds);
   }
 
-  removeConflicts();
+  AVarBoundsConflictResolver::resolveConflicts(this);
 
   PStats.endArrayBoundsInferenceTime();
 }

--- a/clang/lib/3C/AVarBoundsInfo.cpp
+++ b/clang/lib/3C/AVarBoundsInfo.cpp
@@ -1499,10 +1499,9 @@ void AVarBoundsInfo::getBoundsNeededArrPointers(std::set<BoundsKey> &AB) const {
 // In the above case, we use n as a potential count bounds for arr.
 // Note: we only use potential bounds for a variable when none of its
 // predecessors have bounds.
-void AVarBoundsInfo::performFlowAnalysis(ProgramInfo *PI) {
+void AVarBoundsInfo::performFlowAnalysis(ProgramInfo *PI, bool ResolveConflits) {
   auto &PStats = PI->getPerfStats();
   PStats.startArrayBoundsInferenceTime();
-  AVarBoundsConflictResolver AVarBoundsConflictResolver;
 
   // First get all the pointer vars which are ARRs. Results is stored in the
   // field ArrPointerBoundsKey. This also populates some other sets that seem to
@@ -1569,9 +1568,10 @@ void AVarBoundsInfo::performFlowAnalysis(ProgramInfo *PI) {
     }
     OuterChanged = (TmpArrNeededBounds != ArrNeededBounds);
   }
-
-  AVarBoundsConflictResolver.resolveConflicts(this);
-
+  if (ResolveConflits) {
+    AVarBoundsConflictResolver AVarBoundsConflictResolver;
+    AVarBoundsConflictResolver.resolveConflicts(this);
+  }
   PStats.endArrayBoundsInferenceTime();
 }
 

--- a/clang/lib/3C/AVarBoundsInfo.cpp
+++ b/clang/lib/3C/AVarBoundsInfo.cpp
@@ -1782,7 +1782,10 @@ PVConstraint *AVarBoundsInfo::getConstraintVariable(const ProgramInfo *PI,
   const auto &VariableMap = DeclVarMap.right();
   if (VariableMap.find(BK) != VariableMap.end()) {
     const PersistentSourceLoc &PSL = VariableMap.at(BK);
-    return dyn_cast<PVConstraint>(PI->getVarMap().at(PSL));
+    if (PI->getVarMap().count(PSL) > 0)
+        return dyn_cast<PVConstraint>(PI->getVarMap().at(PSL));
+    else
+        return nullptr;
   }
 
   // Function parameters

--- a/clang/lib/3C/CMakeLists.txt
+++ b/clang/lib/3C/CMakeLists.txt
@@ -28,6 +28,7 @@ endif()
 add_clang_library(clang3C
   ABounds.cpp
   AVarBoundsInfo.cpp
+  AVarBoundsConflictResolver.cpp
   AVarGraph.cpp
   ArrayBoundsInferenceConsumer.cpp
   CastPlacement.cpp

--- a/clang/lib/3C/Constraints.cpp
+++ b/clang/lib/3C/Constraints.cpp
@@ -588,7 +588,6 @@ void Constraints::clear() {
   TheConstraints.clear();
   ConstraintsByReason.clear();
   resetEnvironment();
-
 }
 
 bool Constraints::checkInitialEnvSanity() {

--- a/clang/lib/3C/Constraints.cpp
+++ b/clang/lib/3C/Constraints.cpp
@@ -584,6 +584,13 @@ void Constraints::resetEnvironment() {
   Environment.resetFullSolution(getDefaultSolution());
 }
 
+void Constraints::clear() {
+  TheConstraints.clear();
+  ConstraintsByReason.clear();
+  resetEnvironment();
+
+}
+
 bool Constraints::checkInitialEnvSanity() {
   return Environment.checkAssignment(getDefaultSolution());
 }

--- a/clang/lib/3C/MultiDecls.cpp
+++ b/clang/lib/3C/MultiDecls.cpp
@@ -294,6 +294,7 @@ bool ProgramMultiDeclsInfo::wasBaseTypeRenamed(Decl *D) {
     return false;
   return MDI->BaseTypeRenamed;
 }
+
 void ProgramMultiDeclsInfo::clear() {
   UsedTagNames.clear();
   RenamedTagDefs.clear();

--- a/clang/lib/3C/MultiDecls.cpp
+++ b/clang/lib/3C/MultiDecls.cpp
@@ -294,3 +294,8 @@ bool ProgramMultiDeclsInfo::wasBaseTypeRenamed(Decl *D) {
     return false;
   return MDI->BaseTypeRenamed;
 }
+void ProgramMultiDeclsInfo::clear() {
+  UsedTagNames.clear();
+  RenamedTagDefs.clear();
+  TUInfos.clear();
+}

--- a/clang/lib/3C/ProgramInfo.cpp
+++ b/clang/lib/3C/ProgramInfo.cpp
@@ -962,6 +962,7 @@ FVConstraint *ProgramInfo::getStaticFuncConstraint(std::string FuncName,
 // depend on other constraint vars that are directly assigned WILD.
 bool ProgramInfo::computeInterimConstraintState(
     const std::set<std::string> &FilePaths) {
+
   // Get all the valid vars of interest i.e., all the Vars that are present
   // in one of the files being compiled.
   CAtoms ValidVarsVec;
@@ -979,6 +980,7 @@ bool ProgramInfo::computeInterimConstraintState(
         ValidVarsVec.insert(ValidVarsVec.begin(), Tmp.begin(), Tmp.end());
     }
   }
+
   // Make that into set, for efficiency.
   std::set<Atom *> ValidVarsS;
   ValidVarsS.insert(ValidVarsVec.begin(), ValidVarsVec.end());
@@ -995,6 +997,7 @@ bool ProgramInfo::computeInterimConstraintState(
   std::transform(AllValidVars.begin(), AllValidVars.end(),
                  std::inserter(AllValidVarsKey, AllValidVarsKey.end()),
                  GetLocOrZero);
+
   CState.clear();
   std::set<Atom *> DirectWildVarAtoms;
   CS.getChkCG().getSuccessors(CS.getWild(), DirectWildVarAtoms);

--- a/clang/lib/3C/ProgramInfo.cpp
+++ b/clang/lib/3C/ProgramInfo.cpp
@@ -945,7 +945,6 @@ FVConstraint *ProgramInfo::getStaticFuncConstraint(std::string FuncName,
 // depend on other constraint vars that are directly assigned WILD.
 bool ProgramInfo::computeInterimConstraintState(
     const std::set<std::string> &FilePaths) {
-
   // Get all the valid vars of interest i.e., all the Vars that are present
   // in one of the files being compiled.
   CAtoms ValidVarsVec;
@@ -963,7 +962,6 @@ bool ProgramInfo::computeInterimConstraintState(
         ValidVarsVec.insert(ValidVarsVec.begin(), Tmp.begin(), Tmp.end());
     }
   }
-
   // Make that into set, for efficiency.
   std::set<Atom *> ValidVarsS;
   ValidVarsS.insert(ValidVarsVec.begin(), ValidVarsVec.end());
@@ -980,7 +978,6 @@ bool ProgramInfo::computeInterimConstraintState(
   std::transform(AllValidVars.begin(), AllValidVars.end(),
                  std::inserter(AllValidVarsKey, AllValidVarsKey.end()),
                  GetLocOrZero);
-
   CState.clear();
   std::set<Atom *> DirectWildVarAtoms;
   CS.getChkCG().getSuccessors(CS.getWild(), DirectWildVarAtoms);
@@ -1061,6 +1058,24 @@ bool ProgramInfo::computeInterimConstraintState(
 
   computePtrLevelStats();
   return true;
+}
+
+void ProgramInfo::clear() {
+  TheMultiDeclsInfo.clear();
+  Variables.clear();
+  TypedefVars.clear();
+  ExprConstraintVars.clear();
+  ExprLocations.clear();
+  DeletedAtomLocations.clear();
+  CS.clear();
+  ExternGVars.clear();
+  ExternalFunctionFVCons.clear();
+  StaticFunctionFVCons.clear();
+  GlobalVariableSymbols.clear();
+  CState.clear();
+  ArrBInfo.clear();
+  TypeParamBindings.clear();
+  TranslationUnitIdxMap.clear();
 }
 
 void ProgramInfo::insertIntoPtrSourceMap(PersistentSourceLoc PSL,

--- a/clang/lib/3C/ProgramInfo.cpp
+++ b/clang/lib/3C/ProgramInfo.cpp
@@ -23,6 +23,38 @@ ProgramInfo::ProgramInfo() : Persisted(true) {
   StaticFunctionFVCons.clear();
 }
 
+ProgramInfo::~ProgramInfo(){
+  std::set<ConstraintVariable *> CVars;
+  int FndFlag = 0;
+  for (auto &Var : Variables) {
+    for(auto &CVar: CVars) {
+      if (CVar == Var.second) {
+        FndFlag = 1;
+        break;
+      }
+    }
+    if(!FndFlag){
+      CVars.insert(Var.second);
+      delete (Var.second);
+    }
+    FndFlag = 0;
+  }
+
+  for (auto &FVCons : ExternalFunctionFVCons) {
+    for(auto &CVar: CVars) {
+      if (CVar == FVCons.second) {
+        FndFlag = 1;
+        break;
+      }
+    }
+    if(!FndFlag){
+      CVars.insert(FVCons.second);
+      delete (FVCons.second);
+    }
+    FndFlag = 0;
+  }
+}
+
 void dumpExtFuncMap(const ProgramInfo::ExternalFunctionMapType &EMap,
                     raw_ostream &O) {
   for (const auto &DefM : EMap) {

--- a/clang/lib/3C/ProgramInfo.cpp
+++ b/clang/lib/3C/ProgramInfo.cpp
@@ -25,33 +25,18 @@ ProgramInfo::ProgramInfo() : Persisted(true) {
 
 ProgramInfo::~ProgramInfo(){
   std::set<ConstraintVariable *> CVars;
-  int FndFlag = 0;
   for (auto &Var : Variables) {
-    for(auto &CVar: CVars) {
-      if (CVar == Var.second) {
-        FndFlag = 1;
-        break;
-      }
-    }
-    if(!FndFlag){
+    if( CVars.find(Var.second) == CVars.end()){
       CVars.insert(Var.second);
       delete (Var.second);
     }
-    FndFlag = 0;
   }
 
   for (auto &FVCons : ExternalFunctionFVCons) {
-    for(auto &CVar: CVars) {
-      if (CVar == FVCons.second) {
-        FndFlag = 1;
-        break;
+      if( CVars.find(FVCons.second) == CVars.end()){
+        CVars.insert(FVCons.second);
+        delete (FVCons.second);
       }
-    }
-    if(!FndFlag){
-      CVars.insert(FVCons.second);
-      delete (FVCons.second);
-    }
-    FndFlag = 0;
   }
 }
 

--- a/clang/lib/3C/RewriteUtils.cpp
+++ b/clang/lib/3C/RewriteUtils.cpp
@@ -331,7 +331,10 @@ static void emit(Rewriter &R, ASTContext &C, bool &StdoutModeEmittedMainFile) {
         std::string FileName = sys::path::remove_leading_dotslash(PfName).str();
         std::string Ext = sys::path::extension(FileName).str();
         std::string Stem = sys::path::stem(FileName).str();
-        NFile = Stem + "." + _3COpts.OutputPostfix + Ext;
+        if (_3COpts.OutputPostfix=="null")
+          NFile = Stem + Ext;
+        else
+          NFile = Stem + "." + _3COpts.OutputPostfix + Ext;
         if (!DirName.empty())
           NFile = DirName + sys::path::get_separator().str() + NFile;
       } else {

--- a/clang/lib/3C/RewriteUtils.cpp
+++ b/clang/lib/3C/RewriteUtils.cpp
@@ -331,7 +331,7 @@ static void emit(Rewriter &R, ASTContext &C, bool &StdoutModeEmittedMainFile) {
         std::string FileName = sys::path::remove_leading_dotslash(PfName).str();
         std::string Ext = sys::path::extension(FileName).str();
         std::string Stem = sys::path::stem(FileName).str();
-        if (_3COpts.OutputPostfix=="null")
+        if (_3COpts.OutputPostfix == "null")
           NFile = Stem + Ext;
         else
           NFile = Stem + "." + _3COpts.OutputPostfix + Ext;

--- a/clang/lib/3C/Utils.cpp
+++ b/clang/lib/3C/Utils.cpp
@@ -424,38 +424,34 @@ std::string getSourceText(const clang::CharSourceRange &SR,
   return Srctxt.str();
 }
 
-unsigned longestCommonSubsequence(const char* X,const char* Y,
-                            unsigned long m,
-                            unsigned long n)
-{
-    unsigned long L[m + 1][n + 1];
-    unsigned long i, j;
 
-    for (i = 0; i <= m; i++) {
-        for (j = 0; j <= n; j++) {
-            if (i == 0 || j == 0)
-                L[i][j] = 0;
+// The following code implements the Longest Common Subsequence (LCS)
+// algorithm using bottom-up dynamic programming. The code is adapted
+// from a source available at https://www.geeksforgeeks.org/longest-common-subsequence-dp-4/
+// with one modification: the array L, previously stack-allocated,
+// has been replaced with a C++ vector.
+unsigned longestCommonSubsequence(const char *X,
+                                  const char *Y,
+                            	    unsigned long M,
+                            	    unsigned long N)
+{
+  std::vector<std::vector<unsigned long>> L(M + 1, std::vector<unsigned long>(N + 1));
+    unsigned long I, J;
+
+    for (I = 0; I <= M; I++) {
+        for (J = 0; J <= N; J++) {
+            if (I == 0 || J == 0)
+                L[I][J] = 0;
   
-            else if (X[i - 1] == Y[j - 1])
-                L[i][j] = L[i - 1][j - 1] + 1;
+            else if (X[I - 1] == Y[J - 1])
+                L[I][J] = L[I - 1][J - 1] + 1;
   
             else
-                L[i][j] = std::max(L[i - 1][j], L[i][j - 1]);
+                L[I][J] = std::max(L[I - 1][J], L[I][J - 1]);
         }
     }
-  return L[m][n];
+  return L[M][N];
 }
-
-// unsigned longestCommonSubsequence(const char *Str1, const char *Str2,
-//                                   unsigned long Str1Len,
-//                                   unsigned long Str2Len) {
-//   if (Str1Len == 0 || Str2Len == 0)
-//     return 0;
-//   if (Str1[Str1Len - 1] == Str2[Str2Len - 1])
-//     return 1 + longestCommonSubsequence(Str1, Str2, Str1Len - 1, Str2Len - 1);
-//   return std::max(longestCommonSubsequence(Str1, Str2, Str1Len, Str2Len - 1),
-//                   longestCommonSubsequence(Str1, Str2, Str1Len - 1, Str2Len));
-// }
 
 bool isTypeAnonymous(const clang::Type *T) {
   return T->isRecordType() &&

--- a/clang/lib/3C/Utils.cpp
+++ b/clang/lib/3C/Utils.cpp
@@ -424,16 +424,38 @@ std::string getSourceText(const clang::CharSourceRange &SR,
   return Srctxt.str();
 }
 
-unsigned longestCommonSubsequence(const char *Str1, const char *Str2,
-                                  unsigned long Str1Len,
-                                  unsigned long Str2Len) {
-  if (Str1Len == 0 || Str2Len == 0)
-    return 0;
-  if (Str1[Str1Len - 1] == Str2[Str2Len - 1])
-    return 1 + longestCommonSubsequence(Str1, Str2, Str1Len - 1, Str2Len - 1);
-  return std::max(longestCommonSubsequence(Str1, Str2, Str1Len, Str2Len - 1),
-                  longestCommonSubsequence(Str1, Str2, Str1Len - 1, Str2Len));
+unsigned longestCommonSubsequence(const char* X,const char* Y,
+                            unsigned long m,
+                            unsigned long n)
+{
+    unsigned long L[m + 1][n + 1];
+    unsigned long i, j;
+
+    for (i = 0; i <= m; i++) {
+        for (j = 0; j <= n; j++) {
+            if (i == 0 || j == 0)
+                L[i][j] = 0;
+  
+            else if (X[i - 1] == Y[j - 1])
+                L[i][j] = L[i - 1][j - 1] + 1;
+  
+            else
+                L[i][j] = std::max(L[i - 1][j], L[i][j - 1]);
+        }
+    }
+  return L[m][n];
 }
+
+// unsigned longestCommonSubsequence(const char *Str1, const char *Str2,
+//                                   unsigned long Str1Len,
+//                                   unsigned long Str2Len) {
+//   if (Str1Len == 0 || Str2Len == 0)
+//     return 0;
+//   if (Str1[Str1Len - 1] == Str2[Str2Len - 1])
+//     return 1 + longestCommonSubsequence(Str1, Str2, Str1Len - 1, Str2Len - 1);
+//   return std::max(longestCommonSubsequence(Str1, Str2, Str1Len, Str2Len - 1),
+//                   longestCommonSubsequence(Str1, Str2, Str1Len - 1, Str2Len));
+// }
 
 bool isTypeAnonymous(const clang::Type *T) {
   return T->isRecordType() &&

--- a/clang/test/3C/diag_verifier_fail_rerun.c
+++ b/clang/test/3C/diag_verifier_fail_rerun.c
@@ -1,0 +1,15 @@
+// Test that the diagnostic verifier is functioning correctly in 3c, because if
+// it isn't, all the other regression tests that use the diagnostic verifier may
+// not be able to catch the problems they are supposed to catch.
+//
+// This is exactly the same as diag_verifier_pass.c except that the warning
+// message we expect is deliberately wrong, so the diagnostic verifier should
+// fail.
+
+// RUN: rm -rf %t*
+// RUN: not 3c -base-dir=%S -warn-root-cause -rerun %s -- -Xclang -verify -Wno-everything 2>%t.stderr
+// RUN: grep -q "error: 'warning' diagnostics expected but not seen:" %t.stderr
+// RUN: grep -q "error: 'warning' diagnostics seen but not expected:" %t.stderr
+
+// Example warning borrowed from root_cause.c .
+void *x; // expected-warning {{Default oops* type}}

--- a/clang/test/3C/macro_function_call_rerun.c
+++ b/clang/test/3C/macro_function_call_rerun.c
@@ -1,0 +1,97 @@
+// RUN: rm -rf %t*
+// RUN: 3c -base-dir=%S -alltypes -addcr -rerun %s -- -Xclang -verify | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr -rerun %s -- -Xclang -verify | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S -alltypes -addcr -rerun %s -- -Xclang -verify | %clang -c -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked -rerun %s -- -Xclang -verify
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/macro_function_call_rerun.c -rerun -- -Xclang -verify | diff %t.checked/macro_function_call_rerun.c -
+
+// Test fix for https://github.com/correctcomputation/checkedc-clang/issues/439
+// We cannot insert casts on function calls inside macros, so constraints must
+// be generated in way that these calls are accepted by CheckedC without
+// additional casts.
+
+// 3C emits a warning if it fails inserting a cast. Ensure the test fails if
+// this happens.
+// expected-no-diagnostics
+
+// Unsafe call in macro. This would require an _Assume_bounds_cast, but we
+// can't insert it.  Constraints are generated so that the cast isn't needed.
+
+#define macro0                                                                 \
+  void caller0(int *a) { fn0(a); }
+void fn0(int *b) {}
+macro0
+
+//CHECK: #define macro0 \
+//CHECK:   void caller0(int *a) { fn0(a); }
+//CHECK: void fn0(int *b) {}
+//CHECK: macro0
+
+// clang-format messes up this part of the file because it mistakes macro
+// references for other syntactic constructs.
+// clang-format off
+
+// Same as above, but the cast is required on the return.
+
+#define macro1 fn1();
+int *fn1(void) { return 0; }
+void caller1() {
+  int *a = (int *)1;
+  a = macro1
+}
+
+// clang-format on
+
+//CHECK: #define macro1 fn1();
+//CHECK: int *fn1(void) { return 0; }
+//CHECK: void caller1() {
+//CHECK:   int *a = (int *)1;
+//CHECK:   a = macro1
+//CHECK: }
+
+// Checked function call in macro. Doesn't need cast, so no changes required to
+// avoid cast.
+
+#define macro2 fn2(a);
+void fn2(int *b) {}
+void caller2(int *a) { macro2 }
+//CHECK: #define macro2 fn2(a);
+//CHECK: void fn2(_Ptr<int> b) _Checked {}
+//CHECK: void caller2(_Ptr<int> a) _Checked { macro2 }
+
+// Like the first test case, but pointer to a pointer.
+
+#define macro3 fn3(a);
+void fn3(int **g) {}
+void caller3() {
+  int **a = (int **)1;
+  macro3
+}
+//CHECK: #define macro3 fn3(a);
+//CHECK: void fn3(int **g) {}
+//CHECK: void caller3() {
+//CHECK:   int **a = (int **)1;
+//CHECK:   macro3
+//CHECK: }
+
+// Call to function pointer
+#define macro4 fn(a);
+void fn4a(int *g) {}
+void fn4b(int *g) {}
+void caller4() {
+  int *a = (int *)1;
+  void (*fn)(int *) = fn4a;
+  if (0)
+    fn = fn4b;
+  macro4
+}
+//CHECK: #define macro4 fn(a);
+//CHECK: void fn4a(int *g) {}
+//CHECK: void fn4b(int *g) {}
+//CHECK: void caller4() {
+//CHECK:   int *a = (int *)1;
+//CHECK:   _Ptr<void (int *)> fn = fn4a;
+//CHECK:   if (0)
+//CHECK:     fn = fn4b;
+//CHECK:   macro4
+//CHECK: }

--- a/clang/test/3C/macro_function_call_rerun.c
+++ b/clang/test/3C/macro_function_call_rerun.c
@@ -5,14 +5,14 @@
 // RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked -rerun %s -- -Xclang -verify
 // RUN: 3c -base-dir=%t.checked -alltypes %t.checked/macro_function_call_rerun.c -rerun -- -Xclang -verify | diff %t.checked/macro_function_call_rerun.c -
 
+// 3C emits a warning if it fails inserting a cast. Ensure the test fails if
+// this happens.
+// expected-no-diagnostics
+
 // Test fix for https://github.com/correctcomputation/checkedc-clang/issues/439
 // We cannot insert casts on function calls inside macros, so constraints must
 // be generated in way that these calls are accepted by CheckedC without
 // additional casts.
-
-// 3C emits a warning if it fails inserting a cast. Ensure the test fails if
-// this happens.
-// expected-no-diagnostics
 
 // Unsafe call in macro. This would require an _Assume_bounds_cast, but we
 // can't insert it.  Constraints are generated so that the cast isn't needed.

--- a/clang/tools/3c/3CStandalone.cpp
+++ b/clang/tools/3c/3CStandalone.cpp
@@ -479,10 +479,6 @@ int main(int argc, const char **argv) {
     _3CInterface.buildInitialConstraints();
     _3CInterface.solveConstraints();
   }
-  // auto Something = _3CInterface.getWildPtrsInfo();
-  // auto ID = Something.RootWildAtomsWithReason.begin()->first;
-  // //_3CInterface.makeSinglePtrNonWild(ID);
-  // auto Again = _3CInterface.getWildPtrsInfo().RootWildAtomsWithReason;
 
   return _3CInterface.determineExitCode();
 }

--- a/clang/tools/3c/3CStandalone.cpp
+++ b/clang/tools/3c/3CStandalone.cpp
@@ -93,7 +93,8 @@ static cl::opt<std::string> OptOutputPostfix(
     "output-postfix",
     cl::desc("String to insert into the names of updated files just before the "
              "extension (e.g., with -output-postfix=checked, foo.c -> "
-             "foo.checked.c)"),
+             "foo.checked.c.)"
+              "Pass null to overwrite the file with CheckedC annotations."),
     cl::init("-"), cl::cat(_3CCategory));
 
 static cl::opt<std::string> OptOutputDir(

--- a/clang/tools/3c/3CStandalone.cpp
+++ b/clang/tools/3c/3CStandalone.cpp
@@ -465,5 +465,10 @@ int main(int argc, const char **argv) {
 
   // Even if all passes succeeded, we could still have a diagnostic verification
   // failure.
+  auto Something = _3CInterface.getWildPtrsInfo();
+  auto ID = Something.RootWildAtomsWithReason.begin()->first;
+  _3CInterface.makeSinglePtrNonWild(ID);
+  auto Again = _3CInterface.getWildPtrsInfo().RootWildAtomsWithReason;
+
   return _3CInterface.determineExitCode();
 }

--- a/clang/tools/3c/3CStandalone.cpp
+++ b/clang/tools/3c/3CStandalone.cpp
@@ -465,9 +465,16 @@ int main(int argc, const char **argv) {
 
   // Even if all passes succeeded, we could still have a diagnostic verification
   // failure.
+
+  _3CInterface.resetInterface();
+  _3CInterface.parseASTs();
+  _3CInterface.addVariables();
+  _3CInterface.buildInitialConstraints();
+  _3CInterface.solveConstraints();
+
   auto Something = _3CInterface.getWildPtrsInfo();
   auto ID = Something.RootWildAtomsWithReason.begin()->first;
-  _3CInterface.makeSinglePtrNonWild(ID);
+  //_3CInterface.makeSinglePtrNonWild(ID);
   auto Again = _3CInterface.getWildPtrsInfo().RootWildAtomsWithReason;
 
   return _3CInterface.determineExitCode();

--- a/clang/tools/3c/3CStandalone.cpp
+++ b/clang/tools/3c/3CStandalone.cpp
@@ -301,6 +301,11 @@ static cl::opt<bool> OptForceItypes(
     cl::init(false), cl::cat(_3CCategory));
 #endif
 
+static cl::opt<bool> OptReRun(
+    "rerun",
+    cl::desc("Run 3C second time for purpose of 3clsp."),
+    cl::init(false), cl::cat(_3CCategory));
+
 // clang-format on
 
 int main(int argc, const char **argv) {
@@ -465,17 +470,19 @@ int main(int argc, const char **argv) {
 
   // Even if all passes succeeded, we could still have a diagnostic verification
   // failure.
-
-  _3CInterface.resetInterface();
-  _3CInterface.parseASTs();
-  _3CInterface.addVariables();
-  _3CInterface.buildInitialConstraints();
-  _3CInterface.solveConstraints();
-
-  auto Something = _3CInterface.getWildPtrsInfo();
-  auto ID = Something.RootWildAtomsWithReason.begin()->first;
-  //_3CInterface.makeSinglePtrNonWild(ID);
-  auto Again = _3CInterface.getWildPtrsInfo().RootWildAtomsWithReason;
+  if (OptReRun) {
+    if (OptVerbose)
+      errs() << "Running 3C second time.\n";
+    _3CInterface.resetInterface();
+    _3CInterface.parseASTs();
+    _3CInterface.addVariables();
+    _3CInterface.buildInitialConstraints();
+    _3CInterface.solveConstraints();
+  }
+  // auto Something = _3CInterface.getWildPtrsInfo();
+  // auto ID = Something.RootWildAtomsWithReason.begin()->first;
+  // //_3CInterface.makeSinglePtrNonWild(ID);
+  // auto Again = _3CInterface.getWildPtrsInfo().RootWildAtomsWithReason;
 
   return _3CInterface.determineExitCode();
 }


### PR DESCRIPTION
The following changes are added:

- added the code necessary for the vscode extension `3clsp` to work with 3c.
- added a new option to 3c which reruns 3c on the given file
- added additional test cases for the above rerun option 
- includes commits that add a new class to 3c which resolves conflicts from the graphs that 3c uses when solving constraints.