### PR TITLE
Fix 3C testcases

### DIFF
--- a/clang/lib/3C/ConstraintVariables.cpp
+++ b/clang/lib/3C/ConstraintVariables.cpp
@@ -164,7 +164,13 @@ public:
     // This is so we can see if the type _contains_ a typedef.
     if (const auto *TDT = dyn_cast<TypedefType>(QT))
       ToSearch = TDT->desugar();
-    else
+    else if (const auto *EType = dyn_cast<ElaboratedType>(QT)) {
+      // If the type is an elaborated type, desugar that and
+      // check if it is a typedef.
+      QualType TypdefTy = EType->desugar();
+      if (const auto *TypdefTyPtr = dyn_cast<TypedefType>(TypdefTy.getTypePtr()))
+        ToSearch = TypdefTyPtr->desugar();
+    } else
       ToSearch = QT;
     TLF.TraverseType(ToSearch);
     // If we found a typedef then we need to have filled out the name field.

--- a/clang/lib/3C/DeclRewriter.cpp
+++ b/clang/lib/3C/DeclRewriter.cpp
@@ -698,7 +698,11 @@ bool FunctionDeclBuilder::VisitFunctionDecl(FunctionDecl *FD) {
     // implicit declaration uses a typedef, it will be missed. That's fine
     // since an implicit declaration can't be rewritten anyways.
     // There might be other ways it can be null that I'm not aware of.
-    DeclIsTypedef = isa<TypedefType>(TS->getType());
+    QualType QT = TS->getType();
+    if (auto *EType = dyn_cast_or_null<ElaboratedType>(QT)) {
+      QualType TypedefTy = EType->desugar();
+      DeclIsTypedef = isa<TypedefType>(TypedefTy);
+    }
   }
 
   // If we've made this generic we need add "_For_any" or "_Itype_for_any"

--- a/clang/lib/3C/ProgramInfo.cpp
+++ b/clang/lib/3C/ProgramInfo.cpp
@@ -742,15 +742,18 @@ void ProgramInfo::ensureNtCorrect(const QualType &QT,
 
 void ProgramInfo::unifyIfTypedef(const QualType &QT, ASTContext &Context,
                                  PVConstraint *P, ConsAction CA) {
-  if (const auto *TDT = dyn_cast<TypedefType>(QT.getTypePtr())) {
-    auto *TDecl = TDT->getDecl();
-    auto PSL = PersistentSourceLoc::mkPSL(TDecl, Context);
-    auto O = lookupTypedef(PSL);
-    auto Rsn = ReasonLoc("typedef", PSL);
-    if (O.hasValue()) {
-      auto *Bounds = &O.getValue();
-      P->setTypedef(Bounds, TDecl->getNameAsString());
-      constrainConsVarGeq(P, Bounds, CS, Rsn, CA, false, this);
+  if (auto *EType = dyn_cast_or_null<ElaboratedType>(QT)) {
+    QualType TypdefTy = EType->desugar();
+    if (const auto *TDT = dyn_cast<TypedefType>(TypdefTy.getTypePtr())) {
+      auto *TDecl = TDT->getDecl();
+      auto PSL = PersistentSourceLoc::mkPSL(TDecl, Context);
+      auto O = lookupTypedef(PSL);
+      auto Rsn = ReasonLoc("typedef", PSL);
+      if (O.hasValue()) {
+        auto *Bounds = &O.getValue();
+        P->setTypedef(Bounds, TDecl->getNameAsString());
+        constrainConsVarGeq(P, Bounds, CS, Rsn, CA, false, this);
+      }
     }
   }
 }

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -3420,6 +3420,9 @@ void CompilerInvocation::GenerateLangArgs(const LangOptions &Opts,
   if (!Opts.CheckedC)
     GenerateArg(Args, OPT_fno_checkedc_extension, SA);
 
+  if (Opts._3C)
+    GenerateArg(Args, OPT_f3c_tool, SA);
+
   if (Opts.Blocks && !(Opts.OpenCL && Opts.OpenCLVersion == 200))
     GenerateArg(Args, OPT_fblocks, SA);
 

--- a/clang/test/3C/add_struct_init.c
+++ b/clang/test/3C/add_struct_init.c
@@ -1,9 +1,9 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK" %s
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
-// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/add_struct_init.c -- | diff %t.checked/add_struct_init.c -
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK" %s
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -Wno-error=int-conversion | %clang -c -Wno-error=int-conversion -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s -- -Wno-error=int-conversion
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/add_struct_init.c -- -Wno-error=int-conversion | diff %t.checked/add_struct_init.c -
 
 struct foo {};
 struct bar {

--- a/clang/test/3C/arrboundsadvanced.c
+++ b/clang/test/3C/arrboundsadvanced.c
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -alltypes %s -- | FileCheck -match-full-lines %s
-// RUN: 3c -base-dir=%S -alltypes %s -- | %clang -c -f3c-tool -fcheckedc-extension -x c -o %t1.unused -
+// RUN: 3c -base-dir=%S -alltypes %s -- -Wno-error=implicit-function-declaration | FileCheck -match-full-lines %s
+// RUN: 3c -base-dir=%S -alltypes %s -- -Wno-error=implicit-function-declaration | %clang -c -Wno-error=implicit-function-declaration -f3c-tool -fcheckedc-extension -x c -o %t1.unused -
 
 /*
 Advanced array-bounds inference (based on control-dependencies).

--- a/clang/test/3C/b_tests/b11_calleestructnp.c
+++ b/clang/test/3C/b_tests/b11_calleestructnp.c
@@ -1,9 +1,9 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
-// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/b11_calleestructnp.c -- | diff %t.checked/b11_calleestructnp.c -
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=int-conversion | %clang -c -Wno-error=int-conversion -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s -- -Wno-error=int-conversion
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/b11_calleestructnp.c -- -Wno-error=int-conversion | diff %t.checked/b11_calleestructnp.c -
 #include <stddef.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/clang/test/3C/b_tests/b12_callerstructnp.c
+++ b/clang/test/3C/b_tests/b12_callerstructnp.c
@@ -1,9 +1,9 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
-// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/b12_callerstructnp.c -- | diff %t.checked/b12_callerstructnp.c -
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=int-conversion | %clang -c -Wno-error=int-conversion -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s -- -Wno-error=int-conversion
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/b12_callerstructnp.c -- -Wno-error=int-conversion | diff %t.checked/b12_callerstructnp.c -
 #include <stddef.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/clang/test/3C/b_tests/b17_bothstructnp.c
+++ b/clang/test/3C/b_tests/b17_bothstructnp.c
@@ -1,9 +1,9 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
-// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/b17_bothstructnp.c -- | diff %t.checked/b17_bothstructnp.c -
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=int-conversion | %clang -c -Wno-error=int-conversion -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s -- -Wno-error=int-conversion
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/b17_bothstructnp.c -- -Wno-error=int-conversion | diff %t.checked/b17_bothstructnp.c -
 #include <stddef.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/clang/test/3C/b_tests/b21_calleepointerstructproto.c
+++ b/clang/test/3C/b_tests/b21_calleepointerstructproto.c
@@ -1,9 +1,9 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
-// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/b21_calleepointerstructproto.c -- | diff %t.checked/b21_calleepointerstructproto.c -
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=int-conversion | %clang -c -Wno-error=int-conversion -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s -- -Wno-error=int-conversion
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/b21_calleepointerstructproto.c -- -Wno-error=int-conversion | diff %t.checked/b21_calleepointerstructproto.c -
 #include <stddef.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/clang/test/3C/b_tests/b28_structcastimplicit.c
+++ b/clang/test/3C/b_tests/b28_structcastimplicit.c
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK" %s
 // RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 // RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
 // RUN: 3c -base-dir=%t.checked -alltypes %t.checked/b28_structcastimplicit.c -- | diff %t.checked/b28_structcastimplicit.c -

--- a/clang/test/3C/b_tests/b28_structimplicitretcast.c
+++ b/clang/test/3C/b_tests/b28_structimplicitretcast.c
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK" %s
 // RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 // RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
 // RUN: 3c -base-dir=%t.checked -alltypes %t.checked/b28_structimplicitretcast.c -- | diff %t.checked/b28_structimplicitretcast.c -

--- a/clang/test/3C/b_tests/b8_allsafestructnp.c
+++ b/clang/test/3C/b_tests/b8_allsafestructnp.c
@@ -1,9 +1,9 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
-// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/b8_allsafestructnp.c -- | diff %t.checked/b8_allsafestructnp.c -
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=int-conversion | %clang -c -Wno-error=int-conversion -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s -- -Wno-error=int-conversion
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/b8_allsafestructnp.c -- -Wno-error=int-conversion | diff %t.checked/b8_allsafestructnp.c -
 #include <stddef.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/clang/test/3C/b_tests/b9_allsafestructp.c
+++ b/clang/test/3C/b_tests/b9_allsafestructp.c
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK" %s
 // RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 // RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
 // RUN: 3c -base-dir=%t.checked -alltypes %t.checked/b9_allsafestructp.c -- | diff %t.checked/b9_allsafestructp.c -

--- a/clang/test/3C/base_subdir/unwritable_bounds.c
+++ b/clang/test/3C/base_subdir/unwritable_bounds.c
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t*
 // RUN: cd %S
-// RUN: 3c -alltypes -addcr -output-dir=%t.checked/base_subdir %s --
+// RUN: 3c -alltypes -addcr -output-dir=%t.checked/base_subdir %s -- -Wno-error=int-conversion
 
 // The functions called from this file would normally have bounds inferred if
 // they were declared in a writable file. The file is not writable, so the new

--- a/clang/test/3C/basic.c
+++ b/clang/test/3C/basic.c
@@ -1,6 +1,6 @@
-// RUN: 3c -base-dir=%S -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
-// RUN: 3c -base-dir=%S %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
-// RUN: 3c -base-dir=%S %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes %s -- -Wno-error=implicit-function-declaration | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S %s -- -Wno-error=implicit-function-declaration | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S %s -- -Wno-error=implicit-function-declaration | %clang -c -Wno-error=implicit-function-declaration -fcheckedc-extension -x c -o /dev/null -
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/clang/test/3C/cast.c
+++ b/clang/test/3C/cast.c
@@ -1,9 +1,9 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
-// RUN: 3c -base-dir=%S -output-dir=%t.checked -alltypes %s --
-// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/cast.c -- | diff %t.checked/cast.c -
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=int-conversion | %clang -c -Wno-error=int-conversion -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -output-dir=%t.checked -alltypes %s -- -Wno-error=int-conversion
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/cast.c -- -Wno-error=int-conversion | diff %t.checked/cast.c -
 
 int foo(int *p) {
   //CHECK: int foo(_Ptr<int> p) {

--- a/clang/test/3C/checkedregions.c
+++ b/clang/test/3C/checkedregions.c
@@ -1,9 +1,9 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
-// RUN: 3c -base-dir=%S -output-dir=%t.checked -alltypes %s --
-// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/checkedregions.c -- | diff %t.checked/checkedregions.c -
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=int-conversion | %clang -c -Wno-error=int-conversion -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -output-dir=%t.checked -alltypes %s -- -Wno-error=int-conversion
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/checkedregions.c -- -Wno-error=int-conversion | diff %t.checked/checkedregions.c -
 /* Tests for adding (un)checked regions automatically */
 
 #include <stddef.h>

--- a/clang/test/3C/complex_expression.c
+++ b/clang/test/3C/complex_expression.c
@@ -2,11 +2,11 @@
 //
 // Tests 3c tool for complex expressions
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -addcr -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
-// RUN: 3c -base-dir=%S -addcr -output-dir=%t.checked %s --
-// RUN: 3c -base-dir=%t.checked -addcr %t.checked/complex_expression.c -- | diff %t.checked/complex_expression.c -
+// RUN: 3c -base-dir=%S -addcr -alltypes %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=int-conversion | %clang -c -Wno-error=int-conversion -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -addcr -output-dir=%t.checked %s -- -Wno-error=int-conversion
+// RUN: 3c -base-dir=%t.checked -addcr %t.checked/complex_expression.c -- -Wno-error=int-conversion | diff %t.checked/complex_expression.c -
 
 #include <stddef.h>
 

--- a/clang/test/3C/defn_then_decl.c
+++ b/clang/test/3C/defn_then_decl.c
@@ -1,9 +1,9 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK" %s
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
-// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/defn_then_decl.c -- | diff %t.checked/defn_then_decl.c -
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK" %s
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -Wno-error=int-conversion | %clang -c -Wno-error=int-conversion -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s -- -Wno-error=int-conversion
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/defn_then_decl.c -- -Wno-error=int-conversion | diff %t.checked/defn_then_decl.c -
 
 // Tests behavior when a function declaration appears after the definition for
 // that function. A specific issue that existed caused constraints applied to

--- a/clang/test/3C/dont_add_prototype.c
+++ b/clang/test/3C/dont_add_prototype.c
@@ -1,9 +1,9 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK" %s
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
-// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/dont_add_prototype.c -- | diff %t.checked/dont_add_prototype.c -
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK" %s
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -Wno-error=int-conversion | %clang -c -Wno-error=int-conversion -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s -- -Wno-error=int-conversion
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/dont_add_prototype.c -- -Wno-error=int-conversion | diff %t.checked/dont_add_prototype.c -
 
 // Don't add a void prototype on functions if we don't need to. This can
 // potentially cause rewriting errors when attempting to rewrite functions

--- a/clang/test/3C/fptr_array.c
+++ b/clang/test/3C/fptr_array.c
@@ -1,9 +1,9 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -w | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- -w | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- -w | %clang -c -fcheckedc-extension -x c -o /dev/null -
-// RUN: 3c -base-dir=%S -output-dir=%t.checked -alltypes %s -- -w
-// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/fptr_array.c -- -w | diff %t.checked/fptr_array.c -
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -Wno-error=int-conversion -w | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=int-conversion -w | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=int-conversion -w | %clang -c -Wno-error=int-conversion -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -output-dir=%t.checked -alltypes %s -- -Wno-error=int-conversion -w
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/fptr_array.c -- -Wno-error=int-conversion -w | diff %t.checked/fptr_array.c -
 
 // Test function pointers as elements of fixed size arrays.
 

--- a/clang/test/3C/functionDeclEnd.c
+++ b/clang/test/3C/functionDeclEnd.c
@@ -1,9 +1,9 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -addcr -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr -alltypes %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
-// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/functionDeclEnd.c -- | diff %t.checked/functionDeclEnd.c -
+// RUN: 3c -base-dir=%S -addcr -alltypes %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr -alltypes %s -- -Wno-error=int-conversion | %clang -c -Wno-error=int-conversion -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s -- -Wno-error=int-conversion
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/functionDeclEnd.c -- -Wno-error=int-conversion | diff %t.checked/functionDeclEnd.c -
 
 // Tests for issue 392. When rewriting function prototypes sometimes code
 // falling between the start of the definition and the end of the prototype

--- a/clang/test/3C/generalize.c
+++ b/clang/test/3C/generalize.c
@@ -1,8 +1,8 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines %s
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
-// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/generalize.c -- | diff %t.checked/generalize.c -
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -Wno-error=int-conversion -Wno-error=implicit-int -Wno-error=incompatible-function-pointer-types | FileCheck -match-full-lines %s
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -Wno-error=int-conversion -Wno-error=implicit-int -Wno-error=incompatible-function-pointer-types | %clang -c -Wno-error=int-conversion -Wno-error=implicit-int -Wno-error=incompatible-function-pointer-types -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s -- -Wno-error=int-conversion -Wno-error=implicit-int -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/generalize.c -- -Wno-error=int-conversion -Wno-error=implicit-int -Wno-error=incompatible-function-pointer-types | diff %t.checked/generalize.c -
 
 // Test the code that adds generics to replace void*
 

--- a/clang/test/3C/generated_tests/fptrunsafeboth.c
+++ b/clang/test/3C/generated_tests/fptrunsafeboth.c
@@ -1,10 +1,10 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -Wno-error=incompatible-function-pointer-types | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=incompatible-function-pointer-types | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=incompatible-function-pointer-types | %clang -c -Wno-error=incompatible-function-pointer-types -fcheckedc-extension -x c -o /dev/null -
 
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
-// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/fptrunsafeboth.c -- | diff %t.checked/fptrunsafeboth.c -
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/fptrunsafeboth.c -- -Wno-error=incompatible-function-pointer-types | diff %t.checked/fptrunsafeboth.c -
 
 /******************************************************************************/
 

--- a/clang/test/3C/generated_tests/fptrunsafebothmulti1.c
+++ b/clang/test/3C/generated_tests/fptrunsafebothmulti1.c
@@ -1,11 +1,11 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -addcr -alltypes -output-dir=%t.checkedALL %s %S/fptrunsafebothmulti2.c --
-// RUN: 3c -base-dir=%S -addcr -output-dir=%t.checkedNOALL %s %S/fptrunsafebothmulti2.c --
-// RUN: %clang -working-directory=%t.checkedNOALL -c fptrunsafebothmulti1.c fptrunsafebothmulti2.c
+// RUN: 3c -base-dir=%S -addcr -alltypes -output-dir=%t.checkedALL %s %S/fptrunsafebothmulti2.c -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%S -addcr -output-dir=%t.checkedNOALL %s %S/fptrunsafebothmulti2.c -- -Wno-error=incompatible-function-pointer-types
+// RUN: %clang -working-directory=%t.checkedNOALL -c -Wno-error=incompatible-function-pointer-types fptrunsafebothmulti1.c fptrunsafebothmulti2.c
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" --input-file %t.checkedNOALL/fptrunsafebothmulti1.c %s
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %t.checkedALL/fptrunsafebothmulti1.c %s
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %S/fptrunsafebothmulti2.c %s --
-// RUN: 3c -base-dir=%t.checked -alltypes -output-dir=%t.convert_again %t.checked/fptrunsafebothmulti1.c %t.checked/fptrunsafebothmulti2.c --
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %S/fptrunsafebothmulti2.c %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%t.checked -alltypes -output-dir=%t.convert_again %t.checked/fptrunsafebothmulti1.c %t.checked/fptrunsafebothmulti2.c -- -Wno-error=incompatible-function-pointer-types
 // RUN: test ! -f %t.convert_again/fptrunsafebothmulti1.c
 // RUN: test ! -f %t.convert_again/fptrunsafebothmulti2.c
 

--- a/clang/test/3C/generated_tests/fptrunsafebothmulti2.c
+++ b/clang/test/3C/generated_tests/fptrunsafebothmulti2.c
@@ -1,11 +1,11 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -addcr -alltypes -output-dir=%t.checkedALL2 %S/fptrunsafebothmulti1.c %s --
-// RUN: 3c -base-dir=%S -addcr -output-dir=%t.checkedNOALL2 %S/fptrunsafebothmulti1.c %s --
-// RUN: %clang -working-directory=%t.checkedNOALL2 -c fptrunsafebothmulti1.c fptrunsafebothmulti2.c
+// RUN: 3c -base-dir=%S -addcr -alltypes -output-dir=%t.checkedALL2 %S/fptrunsafebothmulti1.c %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%S -addcr -output-dir=%t.checkedNOALL2 %S/fptrunsafebothmulti1.c %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: %clang -working-directory=%t.checkedNOALL2 -c -Wno-error=incompatible-function-pointer-types fptrunsafebothmulti1.c fptrunsafebothmulti2.c
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" --input-file %t.checkedNOALL2/fptrunsafebothmulti2.c %s
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %t.checkedALL2/fptrunsafebothmulti2.c %s
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %S/fptrunsafebothmulti1.c %s --
-// RUN: 3c -base-dir=%t.checked -alltypes -output-dir=%t.convert_again %t.checked/fptrunsafebothmulti1.c %t.checked/fptrunsafebothmulti2.c --
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %S/fptrunsafebothmulti1.c %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%t.checked -alltypes -output-dir=%t.convert_again %t.checked/fptrunsafebothmulti1.c %t.checked/fptrunsafebothmulti2.c -- -Wno-error=incompatible-function-pointer-types
 // RUN: test ! -f %t.convert_again/fptrunsafebothmulti1.c
 // RUN: test ! -f %t.convert_again/fptrunsafebothmulti2.c
 

--- a/clang/test/3C/generated_tests/fptrunsafecallee.c
+++ b/clang/test/3C/generated_tests/fptrunsafecallee.c
@@ -1,10 +1,10 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -Wno-error=incompatible-function-pointer-types | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=incompatible-function-pointer-types | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=incompatible-function-pointer-types | %clang -c -Wno-error=incompatible-function-pointer-types -fcheckedc-extension -x c -o /dev/null -
 
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
-// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/fptrunsafecallee.c -- | diff %t.checked/fptrunsafecallee.c -
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/fptrunsafecallee.c -- -Wno-error=incompatible-function-pointer-types | diff %t.checked/fptrunsafecallee.c -
 
 /******************************************************************************/
 

--- a/clang/test/3C/generated_tests/fptrunsafecalleemulti1.c
+++ b/clang/test/3C/generated_tests/fptrunsafecalleemulti1.c
@@ -1,11 +1,11 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -addcr -alltypes -output-dir=%t.checkedALL %s %S/fptrunsafecalleemulti2.c --
-// RUN: 3c -base-dir=%S -addcr -output-dir=%t.checkedNOALL %s %S/fptrunsafecalleemulti2.c --
-// RUN: %clang -working-directory=%t.checkedNOALL -c fptrunsafecalleemulti1.c fptrunsafecalleemulti2.c
+// RUN: 3c -base-dir=%S -addcr -alltypes -output-dir=%t.checkedALL %s %S/fptrunsafecalleemulti2.c -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%S -addcr -output-dir=%t.checkedNOALL %s %S/fptrunsafecalleemulti2.c -- -Wno-error=incompatible-function-pointer-types
+// RUN: %clang -working-directory=%t.checkedNOALL -c -Wno-error=incompatible-function-pointer-types fptrunsafecalleemulti1.c fptrunsafecalleemulti2.c
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" --input-file %t.checkedNOALL/fptrunsafecalleemulti1.c %s
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %t.checkedALL/fptrunsafecalleemulti1.c %s
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %S/fptrunsafecalleemulti2.c %s --
-// RUN: 3c -base-dir=%t.checked -alltypes -output-dir=%t.convert_again %t.checked/fptrunsafecalleemulti1.c %t.checked/fptrunsafecalleemulti2.c --
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %S/fptrunsafecalleemulti2.c %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%t.checked -alltypes -output-dir=%t.convert_again %t.checked/fptrunsafecalleemulti1.c %t.checked/fptrunsafecalleemulti2.c -- -Wno-error=incompatible-function-pointer-types
 // RUN: test ! -f %t.convert_again/fptrunsafecalleemulti1.c
 // RUN: test ! -f %t.convert_again/fptrunsafecalleemulti2.c
 

--- a/clang/test/3C/generated_tests/fptrunsafecalleemulti2.c
+++ b/clang/test/3C/generated_tests/fptrunsafecalleemulti2.c
@@ -1,11 +1,11 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -addcr -alltypes -output-dir=%t.checkedALL2 %S/fptrunsafecalleemulti1.c %s --
-// RUN: 3c -base-dir=%S -addcr -output-dir=%t.checkedNOALL2 %S/fptrunsafecalleemulti1.c %s --
-// RUN: %clang -working-directory=%t.checkedNOALL2 -c fptrunsafecalleemulti1.c fptrunsafecalleemulti2.c
+// RUN: 3c -base-dir=%S -addcr -alltypes -output-dir=%t.checkedALL2 %S/fptrunsafecalleemulti1.c %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%S -addcr -output-dir=%t.checkedNOALL2 %S/fptrunsafecalleemulti1.c %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: %clang -working-directory=%t.checkedNOALL2 -c -Wno-error=incompatible-function-pointer-types fptrunsafecalleemulti1.c fptrunsafecalleemulti2.c
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" --input-file %t.checkedNOALL2/fptrunsafecalleemulti2.c %s
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %t.checkedALL2/fptrunsafecalleemulti2.c %s
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %S/fptrunsafecalleemulti1.c %s --
-// RUN: 3c -base-dir=%t.checked -alltypes -output-dir=%t.convert_again %t.checked/fptrunsafecalleemulti1.c %t.checked/fptrunsafecalleemulti2.c --
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %S/fptrunsafecalleemulti1.c %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%t.checked -alltypes -output-dir=%t.convert_again %t.checked/fptrunsafecalleemulti1.c %t.checked/fptrunsafecalleemulti2.c -- -Wno-error=incompatible-function-pointer-types
 // RUN: test ! -f %t.convert_again/fptrunsafecalleemulti1.c
 // RUN: test ! -f %t.convert_again/fptrunsafecalleemulti2.c
 

--- a/clang/test/3C/generated_tests/fptrunsafecaller.c
+++ b/clang/test/3C/generated_tests/fptrunsafecaller.c
@@ -1,10 +1,10 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -Wno-error=incompatible-function-pointer-types | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=incompatible-function-pointer-types | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=incompatible-function-pointer-types | %clang -c -Wno-error=incompatible-function-pointer-types -fcheckedc-extension -x c -o /dev/null -
 
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
-// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/fptrunsafecaller.c -- | diff %t.checked/fptrunsafecaller.c -
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/fptrunsafecaller.c -- -Wno-error=incompatible-function-pointer-types | diff %t.checked/fptrunsafecaller.c -
 
 /******************************************************************************/
 

--- a/clang/test/3C/generated_tests/fptrunsafecallermulti1.c
+++ b/clang/test/3C/generated_tests/fptrunsafecallermulti1.c
@@ -1,11 +1,11 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -addcr -alltypes -output-dir=%t.checkedALL %s %S/fptrunsafecallermulti2.c --
-// RUN: 3c -base-dir=%S -addcr -output-dir=%t.checkedNOALL %s %S/fptrunsafecallermulti2.c --
-// RUN: %clang -working-directory=%t.checkedNOALL -c fptrunsafecallermulti1.c fptrunsafecallermulti2.c
+// RUN: 3c -base-dir=%S -addcr -alltypes -output-dir=%t.checkedALL %s %S/fptrunsafecallermulti2.c -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%S -addcr -output-dir=%t.checkedNOALL %s %S/fptrunsafecallermulti2.c -- -Wno-error=incompatible-function-pointer-types
+// RUN: %clang -working-directory=%t.checkedNOALL -c -Wno-error=incompatible-function-pointer-types fptrunsafecallermulti1.c fptrunsafecallermulti2.c
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" --input-file %t.checkedNOALL/fptrunsafecallermulti1.c %s
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %t.checkedALL/fptrunsafecallermulti1.c %s
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %S/fptrunsafecallermulti2.c %s --
-// RUN: 3c -base-dir=%t.checked -alltypes -output-dir=%t.convert_again %t.checked/fptrunsafecallermulti1.c %t.checked/fptrunsafecallermulti2.c --
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %S/fptrunsafecallermulti2.c %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%t.checked -alltypes -output-dir=%t.convert_again %t.checked/fptrunsafecallermulti1.c %t.checked/fptrunsafecallermulti2.c -- -Wno-error=incompatible-function-pointer-types
 // RUN: test ! -f %t.convert_again/fptrunsafecallermulti1.c
 // RUN: test ! -f %t.convert_again/fptrunsafecallermulti2.c
 

--- a/clang/test/3C/generated_tests/fptrunsafecallermulti2.c
+++ b/clang/test/3C/generated_tests/fptrunsafecallermulti2.c
@@ -1,11 +1,11 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -addcr -alltypes -output-dir=%t.checkedALL2 %S/fptrunsafecallermulti1.c %s --
-// RUN: 3c -base-dir=%S -addcr -output-dir=%t.checkedNOALL2 %S/fptrunsafecallermulti1.c %s --
-// RUN: %clang -working-directory=%t.checkedNOALL2 -c fptrunsafecallermulti1.c fptrunsafecallermulti2.c
+// RUN: 3c -base-dir=%S -addcr -alltypes -output-dir=%t.checkedALL2 %S/fptrunsafecallermulti1.c %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%S -addcr -output-dir=%t.checkedNOALL2 %S/fptrunsafecallermulti1.c %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: %clang -working-directory=%t.checkedNOALL2 -c -Wno-error=incompatible-function-pointer-types fptrunsafecallermulti1.c fptrunsafecallermulti2.c
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" --input-file %t.checkedNOALL2/fptrunsafecallermulti2.c %s
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %t.checkedALL2/fptrunsafecallermulti2.c %s
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %S/fptrunsafecallermulti1.c %s --
-// RUN: 3c -base-dir=%t.checked -alltypes -output-dir=%t.convert_again %t.checked/fptrunsafecallermulti1.c %t.checked/fptrunsafecallermulti2.c --
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %S/fptrunsafecallermulti1.c %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%t.checked -alltypes -output-dir=%t.convert_again %t.checked/fptrunsafecallermulti1.c %t.checked/fptrunsafecallermulti2.c -- -Wno-error=incompatible-function-pointer-types
 // RUN: test ! -f %t.convert_again/fptrunsafecallermulti1.c
 // RUN: test ! -f %t.convert_again/fptrunsafecallermulti2.c
 

--- a/clang/test/3C/generated_tests/fptrunsafeprotoboth.c
+++ b/clang/test/3C/generated_tests/fptrunsafeprotoboth.c
@@ -1,10 +1,10 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -Wno-error=incompatible-function-pointer-types | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=incompatible-function-pointer-types | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=incompatible-function-pointer-types | %clang -c -Wno-error=incompatible-function-pointer-types -fcheckedc-extension -x c -o /dev/null -
 
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
-// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/fptrunsafeprotoboth.c -- | diff %t.checked/fptrunsafeprotoboth.c -
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/fptrunsafeprotoboth.c -- -Wno-error=incompatible-function-pointer-types | diff %t.checked/fptrunsafeprotoboth.c -
 
 /******************************************************************************/
 

--- a/clang/test/3C/generated_tests/fptrunsafeprotocallee.c
+++ b/clang/test/3C/generated_tests/fptrunsafeprotocallee.c
@@ -1,10 +1,10 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -Wno-error=incompatible-function-pointer-types | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=incompatible-function-pointer-types | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=incompatible-function-pointer-types | %clang -c -Wno-error=incompatible-function-pointer-types -fcheckedc-extension -x c -o /dev/null -
 
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
-// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/fptrunsafeprotocallee.c -- | diff %t.checked/fptrunsafeprotocallee.c -
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/fptrunsafeprotocallee.c -- -Wno-error=incompatible-function-pointer-types | diff %t.checked/fptrunsafeprotocallee.c -
 
 /******************************************************************************/
 

--- a/clang/test/3C/generated_tests/fptrunsafeprotocaller.c
+++ b/clang/test/3C/generated_tests/fptrunsafeprotocaller.c
@@ -1,10 +1,10 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -Wno-error=incompatible-function-pointer-types | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=incompatible-function-pointer-types | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=incompatible-function-pointer-types | %clang -c -Wno-error=incompatible-function-pointer-types -fcheckedc-extension -x c -o /dev/null -
 
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
-// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/fptrunsafeprotocaller.c -- | diff %t.checked/fptrunsafeprotocaller.c -
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/fptrunsafeprotocaller.c -- -Wno-error=incompatible-function-pointer-types | diff %t.checked/fptrunsafeprotocaller.c -
 
 /******************************************************************************/
 

--- a/clang/test/3C/generated_tests/fptrunsafeprotosafe.c
+++ b/clang/test/3C/generated_tests/fptrunsafeprotosafe.c
@@ -1,10 +1,10 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -Wno-error=incompatible-function-pointer-types | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=incompatible-function-pointer-types | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=incompatible-function-pointer-types | %clang -c -Wno-error=incompatible-function-pointer-types -fcheckedc-extension -x c -o /dev/null -
 
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
-// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/fptrunsafeprotosafe.c -- | diff %t.checked/fptrunsafeprotosafe.c -
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/fptrunsafeprotosafe.c -- -Wno-error=incompatible-function-pointer-types | diff %t.checked/fptrunsafeprotosafe.c -
 
 /******************************************************************************/
 

--- a/clang/test/3C/generated_tests/fptrunsafesafe.c
+++ b/clang/test/3C/generated_tests/fptrunsafesafe.c
@@ -1,10 +1,10 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -Wno-error=incompatible-function-pointer-types | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=incompatible-function-pointer-types | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=incompatible-function-pointer-types | %clang -c -Wno-error=incompatible-function-pointer-types -fcheckedc-extension -x c -o /dev/null -
 
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
-// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/fptrunsafesafe.c -- | diff %t.checked/fptrunsafesafe.c -
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/fptrunsafesafe.c -- -Wno-error=incompatible-function-pointer-types | diff %t.checked/fptrunsafesafe.c -
 
 /******************************************************************************/
 

--- a/clang/test/3C/generated_tests/fptrunsafesafemulti1.c
+++ b/clang/test/3C/generated_tests/fptrunsafesafemulti1.c
@@ -1,11 +1,11 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -addcr -alltypes -output-dir=%t.checkedALL %s %S/fptrunsafesafemulti2.c --
-// RUN: 3c -base-dir=%S -addcr -output-dir=%t.checkedNOALL %s %S/fptrunsafesafemulti2.c --
-// RUN: %clang -working-directory=%t.checkedNOALL -c fptrunsafesafemulti1.c fptrunsafesafemulti2.c
+// RUN: 3c -base-dir=%S -addcr -alltypes -output-dir=%t.checkedALL %s %S/fptrunsafesafemulti2.c -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%S -addcr -output-dir=%t.checkedNOALL %s %S/fptrunsafesafemulti2.c -- -Wno-error=incompatible-function-pointer-types
+// RUN: %clang -working-directory=%t.checkedNOALL -c -Wno-error=incompatible-function-pointer-types fptrunsafesafemulti1.c fptrunsafesafemulti2.c
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" --input-file %t.checkedNOALL/fptrunsafesafemulti1.c %s
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %t.checkedALL/fptrunsafesafemulti1.c %s
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %S/fptrunsafesafemulti2.c %s --
-// RUN: 3c -base-dir=%t.checked -alltypes -output-dir=%t.convert_again %t.checked/fptrunsafesafemulti1.c %t.checked/fptrunsafesafemulti2.c --
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %S/fptrunsafesafemulti2.c %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%t.checked -alltypes -output-dir=%t.convert_again %t.checked/fptrunsafesafemulti1.c %t.checked/fptrunsafesafemulti2.c -- -Wno-error=incompatible-function-pointer-types
 // RUN: test ! -f %t.convert_again/fptrunsafesafemulti1.c
 // RUN: test ! -f %t.convert_again/fptrunsafesafemulti2.c
 

--- a/clang/test/3C/generated_tests/fptrunsafesafemulti2.c
+++ b/clang/test/3C/generated_tests/fptrunsafesafemulti2.c
@@ -1,11 +1,11 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -addcr -alltypes -output-dir=%t.checkedALL2 %S/fptrunsafesafemulti1.c %s --
-// RUN: 3c -base-dir=%S -addcr -output-dir=%t.checkedNOALL2 %S/fptrunsafesafemulti1.c %s --
-// RUN: %clang -working-directory=%t.checkedNOALL2 -c fptrunsafesafemulti1.c fptrunsafesafemulti2.c
+// RUN: 3c -base-dir=%S -addcr -alltypes -output-dir=%t.checkedALL2 %S/fptrunsafesafemulti1.c %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%S -addcr -output-dir=%t.checkedNOALL2 %S/fptrunsafesafemulti1.c %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: %clang -working-directory=%t.checkedNOALL2 -c -Wno-error=incompatible-function-pointer-types fptrunsafesafemulti1.c fptrunsafesafemulti2.c
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" --input-file %t.checkedNOALL2/fptrunsafesafemulti2.c %s
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %t.checkedALL2/fptrunsafesafemulti2.c %s
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %S/fptrunsafesafemulti1.c %s --
-// RUN: 3c -base-dir=%t.checked -alltypes -output-dir=%t.convert_again %t.checked/fptrunsafesafemulti1.c %t.checked/fptrunsafesafemulti2.c --
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %S/fptrunsafesafemulti1.c %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%t.checked -alltypes -output-dir=%t.convert_again %t.checked/fptrunsafesafemulti1.c %t.checked/fptrunsafesafemulti2.c -- -Wno-error=incompatible-function-pointer-types
 // RUN: test ! -f %t.convert_again/fptrunsafesafemulti1.c
 // RUN: test ! -f %t.convert_again/fptrunsafesafemulti2.c
 

--- a/clang/test/3C/generated_tests/unsafefptrargboth.c
+++ b/clang/test/3C/generated_tests/unsafefptrargboth.c
@@ -1,10 +1,10 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -Wno-error=incompatible-function-pointer-types | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=incompatible-function-pointer-types | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=incompatible-function-pointer-types | %clang -c -Wno-error=incompatible-function-pointer-types -fcheckedc-extension -x c -o /dev/null -
 
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
-// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/unsafefptrargboth.c -- | diff %t.checked/unsafefptrargboth.c -
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/unsafefptrargboth.c -- -Wno-error=incompatible-function-pointer-types | diff %t.checked/unsafefptrargboth.c -
 
 /******************************************************************************/
 

--- a/clang/test/3C/generated_tests/unsafefptrargbothmulti1.c
+++ b/clang/test/3C/generated_tests/unsafefptrargbothmulti1.c
@@ -1,11 +1,11 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -addcr -alltypes -output-dir=%t.checkedALL %s %S/unsafefptrargbothmulti2.c --
-// RUN: 3c -base-dir=%S -addcr -output-dir=%t.checkedNOALL %s %S/unsafefptrargbothmulti2.c --
-// RUN: %clang -working-directory=%t.checkedNOALL -c unsafefptrargbothmulti1.c unsafefptrargbothmulti2.c
+// RUN: 3c -base-dir=%S -addcr -alltypes -output-dir=%t.checkedALL %s %S/unsafefptrargbothmulti2.c -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%S -addcr -output-dir=%t.checkedNOALL %s %S/unsafefptrargbothmulti2.c -- -Wno-error=incompatible-function-pointer-types
+// RUN: %clang -working-directory=%t.checkedNOALL -c -Wno-error=incompatible-function-pointer-types unsafefptrargbothmulti1.c unsafefptrargbothmulti2.c
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" --input-file %t.checkedNOALL/unsafefptrargbothmulti1.c %s
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %t.checkedALL/unsafefptrargbothmulti1.c %s
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %S/unsafefptrargbothmulti2.c %s --
-// RUN: 3c -base-dir=%t.checked -alltypes -output-dir=%t.convert_again %t.checked/unsafefptrargbothmulti1.c %t.checked/unsafefptrargbothmulti2.c --
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %S/unsafefptrargbothmulti2.c %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%t.checked -alltypes -output-dir=%t.convert_again %t.checked/unsafefptrargbothmulti1.c %t.checked/unsafefptrargbothmulti2.c -- -Wno-error=incompatible-function-pointer-types
 // RUN: test ! -f %t.convert_again/unsafefptrargbothmulti1.c
 // RUN: test ! -f %t.convert_again/unsafefptrargbothmulti2.c
 

--- a/clang/test/3C/generated_tests/unsafefptrargbothmulti2.c
+++ b/clang/test/3C/generated_tests/unsafefptrargbothmulti2.c
@@ -1,11 +1,11 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -addcr -alltypes -output-dir=%t.checkedALL2 %S/unsafefptrargbothmulti1.c %s --
-// RUN: 3c -base-dir=%S -addcr -output-dir=%t.checkedNOALL2 %S/unsafefptrargbothmulti1.c %s --
-// RUN: %clang -working-directory=%t.checkedNOALL2 -c unsafefptrargbothmulti1.c unsafefptrargbothmulti2.c
+// RUN: 3c -base-dir=%S -addcr -alltypes -output-dir=%t.checkedALL2 %S/unsafefptrargbothmulti1.c %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%S -addcr -output-dir=%t.checkedNOALL2 %S/unsafefptrargbothmulti1.c %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: %clang -working-directory=%t.checkedNOALL2 -c -Wno-error=incompatible-function-pointer-types unsafefptrargbothmulti1.c unsafefptrargbothmulti2.c
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" --input-file %t.checkedNOALL2/unsafefptrargbothmulti2.c %s
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %t.checkedALL2/unsafefptrargbothmulti2.c %s
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %S/unsafefptrargbothmulti1.c %s --
-// RUN: 3c -base-dir=%t.checked -alltypes -output-dir=%t.convert_again %t.checked/unsafefptrargbothmulti1.c %t.checked/unsafefptrargbothmulti2.c --
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %S/unsafefptrargbothmulti1.c %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%t.checked -alltypes -output-dir=%t.convert_again %t.checked/unsafefptrargbothmulti1.c %t.checked/unsafefptrargbothmulti2.c -- -Wno-error=incompatible-function-pointer-types
 // RUN: test ! -f %t.convert_again/unsafefptrargbothmulti1.c
 // RUN: test ! -f %t.convert_again/unsafefptrargbothmulti2.c
 

--- a/clang/test/3C/generated_tests/unsafefptrargcallee.c
+++ b/clang/test/3C/generated_tests/unsafefptrargcallee.c
@@ -1,10 +1,10 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -Wno-error=incompatible-function-pointer-types | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=incompatible-function-pointer-types | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=incompatible-function-pointer-types | %clang -c -Wno-error=incompatible-function-pointer-types -fcheckedc-extension -x c -o /dev/null -
 
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
-// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/unsafefptrargcallee.c -- | diff %t.checked/unsafefptrargcallee.c -
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/unsafefptrargcallee.c -- -Wno-error=incompatible-function-pointer-types | diff %t.checked/unsafefptrargcallee.c -
 
 /******************************************************************************/
 

--- a/clang/test/3C/generated_tests/unsafefptrargcalleemulti1.c
+++ b/clang/test/3C/generated_tests/unsafefptrargcalleemulti1.c
@@ -1,11 +1,11 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -addcr -alltypes -output-dir=%t.checkedALL %s %S/unsafefptrargcalleemulti2.c --
-// RUN: 3c -base-dir=%S -addcr -output-dir=%t.checkedNOALL %s %S/unsafefptrargcalleemulti2.c --
-// RUN: %clang -working-directory=%t.checkedNOALL -c unsafefptrargcalleemulti1.c unsafefptrargcalleemulti2.c
+// RUN: 3c -base-dir=%S -addcr -alltypes -output-dir=%t.checkedALL %s %S/unsafefptrargcalleemulti2.c -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%S -addcr -output-dir=%t.checkedNOALL %s %S/unsafefptrargcalleemulti2.c -- -Wno-error=incompatible-function-pointer-types
+// RUN: %clang -working-directory=%t.checkedNOALL -c -Wno-error=incompatible-function-pointer-types unsafefptrargcalleemulti1.c unsafefptrargcalleemulti2.c
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" --input-file %t.checkedNOALL/unsafefptrargcalleemulti1.c %s
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %t.checkedALL/unsafefptrargcalleemulti1.c %s
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %S/unsafefptrargcalleemulti2.c %s --
-// RUN: 3c -base-dir=%t.checked -alltypes -output-dir=%t.convert_again %t.checked/unsafefptrargcalleemulti1.c %t.checked/unsafefptrargcalleemulti2.c --
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %S/unsafefptrargcalleemulti2.c %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%t.checked -alltypes -output-dir=%t.convert_again %t.checked/unsafefptrargcalleemulti1.c %t.checked/unsafefptrargcalleemulti2.c -- -Wno-error=incompatible-function-pointer-types
 // RUN: test ! -f %t.convert_again/unsafefptrargcalleemulti1.c
 // RUN: test ! -f %t.convert_again/unsafefptrargcalleemulti2.c
 

--- a/clang/test/3C/generated_tests/unsafefptrargcalleemulti2.c
+++ b/clang/test/3C/generated_tests/unsafefptrargcalleemulti2.c
@@ -1,11 +1,11 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -addcr -alltypes -output-dir=%t.checkedALL2 %S/unsafefptrargcalleemulti1.c %s --
-// RUN: 3c -base-dir=%S -addcr -output-dir=%t.checkedNOALL2 %S/unsafefptrargcalleemulti1.c %s --
-// RUN: %clang -working-directory=%t.checkedNOALL2 -c unsafefptrargcalleemulti1.c unsafefptrargcalleemulti2.c
+// RUN: 3c -base-dir=%S -addcr -alltypes -output-dir=%t.checkedALL2 %S/unsafefptrargcalleemulti1.c %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%S -addcr -output-dir=%t.checkedNOALL2 %S/unsafefptrargcalleemulti1.c %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: %clang -working-directory=%t.checkedNOALL2 -c -Wno-error=incompatible-function-pointer-types unsafefptrargcalleemulti1.c unsafefptrargcalleemulti2.c
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" --input-file %t.checkedNOALL2/unsafefptrargcalleemulti2.c %s
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %t.checkedALL2/unsafefptrargcalleemulti2.c %s
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %S/unsafefptrargcalleemulti1.c %s --
-// RUN: 3c -base-dir=%t.checked -alltypes -output-dir=%t.convert_again %t.checked/unsafefptrargcalleemulti1.c %t.checked/unsafefptrargcalleemulti2.c --
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %S/unsafefptrargcalleemulti1.c %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%t.checked -alltypes -output-dir=%t.convert_again %t.checked/unsafefptrargcalleemulti1.c %t.checked/unsafefptrargcalleemulti2.c -- -Wno-error=incompatible-function-pointer-types
 // RUN: test ! -f %t.convert_again/unsafefptrargcalleemulti1.c
 // RUN: test ! -f %t.convert_again/unsafefptrargcalleemulti2.c
 

--- a/clang/test/3C/generated_tests/unsafefptrargcaller.c
+++ b/clang/test/3C/generated_tests/unsafefptrargcaller.c
@@ -1,10 +1,10 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -Wno-error=incompatible-function-pointer-types | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=incompatible-function-pointer-types | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=incompatible-function-pointer-types | %clang -c -Wno-error=incompatible-function-pointer-types -fcheckedc-extension -x c -o /dev/null -
 
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
-// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/unsafefptrargcaller.c -- | diff %t.checked/unsafefptrargcaller.c -
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/unsafefptrargcaller.c -- -Wno-error=incompatible-function-pointer-types | diff %t.checked/unsafefptrargcaller.c -
 
 /******************************************************************************/
 

--- a/clang/test/3C/generated_tests/unsafefptrargcallermulti1.c
+++ b/clang/test/3C/generated_tests/unsafefptrargcallermulti1.c
@@ -1,11 +1,11 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -addcr -alltypes -output-dir=%t.checkedALL %s %S/unsafefptrargcallermulti2.c --
-// RUN: 3c -base-dir=%S -addcr -output-dir=%t.checkedNOALL %s %S/unsafefptrargcallermulti2.c --
-// RUN: %clang -working-directory=%t.checkedNOALL -c unsafefptrargcallermulti1.c unsafefptrargcallermulti2.c
+// RUN: 3c -base-dir=%S -addcr -alltypes -output-dir=%t.checkedALL %s %S/unsafefptrargcallermulti2.c -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%S -addcr -output-dir=%t.checkedNOALL %s %S/unsafefptrargcallermulti2.c -- -Wno-error=incompatible-function-pointer-types
+// RUN: %clang -working-directory=%t.checkedNOALL -c -Wno-error=incompatible-function-pointer-types unsafefptrargcallermulti1.c unsafefptrargcallermulti2.c
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" --input-file %t.checkedNOALL/unsafefptrargcallermulti1.c %s
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %t.checkedALL/unsafefptrargcallermulti1.c %s
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %S/unsafefptrargcallermulti2.c %s --
-// RUN: 3c -base-dir=%t.checked -alltypes -output-dir=%t.convert_again %t.checked/unsafefptrargcallermulti1.c %t.checked/unsafefptrargcallermulti2.c --
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %S/unsafefptrargcallermulti2.c %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%t.checked -alltypes -output-dir=%t.convert_again %t.checked/unsafefptrargcallermulti1.c %t.checked/unsafefptrargcallermulti2.c -- -Wno-error=incompatible-function-pointer-types
 // RUN: test ! -f %t.convert_again/unsafefptrargcallermulti1.c
 // RUN: test ! -f %t.convert_again/unsafefptrargcallermulti2.c
 

--- a/clang/test/3C/generated_tests/unsafefptrargcallermulti2.c
+++ b/clang/test/3C/generated_tests/unsafefptrargcallermulti2.c
@@ -1,11 +1,11 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -addcr -alltypes -output-dir=%t.checkedALL2 %S/unsafefptrargcallermulti1.c %s --
-// RUN: 3c -base-dir=%S -addcr -output-dir=%t.checkedNOALL2 %S/unsafefptrargcallermulti1.c %s --
-// RUN: %clang -working-directory=%t.checkedNOALL2 -c unsafefptrargcallermulti1.c unsafefptrargcallermulti2.c
+// RUN: 3c -base-dir=%S -addcr -alltypes -output-dir=%t.checkedALL2 %S/unsafefptrargcallermulti1.c %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%S -addcr -output-dir=%t.checkedNOALL2 %S/unsafefptrargcallermulti1.c %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: %clang -working-directory=%t.checkedNOALL2 -c -Wno-error=incompatible-function-pointer-types unsafefptrargcallermulti1.c unsafefptrargcallermulti2.c
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" --input-file %t.checkedNOALL2/unsafefptrargcallermulti2.c %s
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %t.checkedALL2/unsafefptrargcallermulti2.c %s
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %S/unsafefptrargcallermulti1.c %s --
-// RUN: 3c -base-dir=%t.checked -alltypes -output-dir=%t.convert_again %t.checked/unsafefptrargcallermulti1.c %t.checked/unsafefptrargcallermulti2.c --
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %S/unsafefptrargcallermulti1.c %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%t.checked -alltypes -output-dir=%t.convert_again %t.checked/unsafefptrargcallermulti1.c %t.checked/unsafefptrargcallermulti2.c -- -Wno-error=incompatible-function-pointer-types
 // RUN: test ! -f %t.convert_again/unsafefptrargcallermulti1.c
 // RUN: test ! -f %t.convert_again/unsafefptrargcallermulti2.c
 

--- a/clang/test/3C/generated_tests/unsafefptrargprotoboth.c
+++ b/clang/test/3C/generated_tests/unsafefptrargprotoboth.c
@@ -1,10 +1,10 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -Wno-error=incompatible-function-pointer-types | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=incompatible-function-pointer-types | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=incompatible-function-pointer-types | %clang -c -Wno-error=incompatible-function-pointer-types -fcheckedc-extension -x c -o /dev/null -
 
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
-// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/unsafefptrargprotoboth.c -- | diff %t.checked/unsafefptrargprotoboth.c -
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/unsafefptrargprotoboth.c -- -Wno-error=incompatible-function-pointer-types | diff %t.checked/unsafefptrargprotoboth.c -
 
 /******************************************************************************/
 

--- a/clang/test/3C/generated_tests/unsafefptrargprotocallee.c
+++ b/clang/test/3C/generated_tests/unsafefptrargprotocallee.c
@@ -1,10 +1,10 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -Wno-error=incompatible-function-pointer-types | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=incompatible-function-pointer-types | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=incompatible-function-pointer-types | %clang -c -Wno-error=incompatible-function-pointer-types -fcheckedc-extension -x c -o /dev/null -
 
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
-// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/unsafefptrargprotocallee.c -- | diff %t.checked/unsafefptrargprotocallee.c -
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/unsafefptrargprotocallee.c -- -Wno-error=incompatible-function-pointer-types | diff %t.checked/unsafefptrargprotocallee.c -
 
 /******************************************************************************/
 

--- a/clang/test/3C/generated_tests/unsafefptrargprotocaller.c
+++ b/clang/test/3C/generated_tests/unsafefptrargprotocaller.c
@@ -1,10 +1,10 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -Wno-error=incompatible-function-pointer-types | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=incompatible-function-pointer-types | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=incompatible-function-pointer-types | %clang -c -Wno-error=incompatible-function-pointer-types -fcheckedc-extension -x c -o /dev/null -
 
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
-// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/unsafefptrargprotocaller.c -- | diff %t.checked/unsafefptrargprotocaller.c -
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/unsafefptrargprotocaller.c -- -Wno-error=incompatible-function-pointer-types | diff %t.checked/unsafefptrargprotocaller.c -
 
 /******************************************************************************/
 

--- a/clang/test/3C/generated_tests/unsafefptrargprotosafe.c
+++ b/clang/test/3C/generated_tests/unsafefptrargprotosafe.c
@@ -1,10 +1,10 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -Wno-error=incompatible-function-pointer-types | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=incompatible-function-pointer-types | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=incompatible-function-pointer-types | %clang -c -Wno-error=incompatible-function-pointer-types -fcheckedc-extension -x c -o /dev/null -
 
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
-// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/unsafefptrargprotosafe.c -- | diff %t.checked/unsafefptrargprotosafe.c -
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/unsafefptrargprotosafe.c -- -Wno-error=incompatible-function-pointer-types | diff %t.checked/unsafefptrargprotosafe.c -
 
 /******************************************************************************/
 

--- a/clang/test/3C/generated_tests/unsafefptrargsafe.c
+++ b/clang/test/3C/generated_tests/unsafefptrargsafe.c
@@ -1,10 +1,10 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -Wno-error=incompatible-function-pointer-types | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=incompatible-function-pointer-types | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=incompatible-function-pointer-types | %clang -c -Wno-error=incompatible-function-pointer-types -fcheckedc-extension -x c -o /dev/null -
 
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
-// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/unsafefptrargsafe.c -- | diff %t.checked/unsafefptrargsafe.c -
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/unsafefptrargsafe.c -- -Wno-error=incompatible-function-pointer-types | diff %t.checked/unsafefptrargsafe.c -
 
 /******************************************************************************/
 

--- a/clang/test/3C/generated_tests/unsafefptrargsafemulti1.c
+++ b/clang/test/3C/generated_tests/unsafefptrargsafemulti1.c
@@ -1,11 +1,11 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -addcr -alltypes -output-dir=%t.checkedALL %s %S/unsafefptrargsafemulti2.c --
-// RUN: 3c -base-dir=%S -addcr -output-dir=%t.checkedNOALL %s %S/unsafefptrargsafemulti2.c --
-// RUN: %clang -working-directory=%t.checkedNOALL -c unsafefptrargsafemulti1.c unsafefptrargsafemulti2.c
+// RUN: 3c -base-dir=%S -addcr -alltypes -output-dir=%t.checkedALL %s %S/unsafefptrargsafemulti2.c -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%S -addcr -output-dir=%t.checkedNOALL %s %S/unsafefptrargsafemulti2.c -- -Wno-error=incompatible-function-pointer-types
+// RUN: %clang -working-directory=%t.checkedNOALL -c -Wno-error=incompatible-function-pointer-types unsafefptrargsafemulti1.c unsafefptrargsafemulti2.c
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" --input-file %t.checkedNOALL/unsafefptrargsafemulti1.c %s
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %t.checkedALL/unsafefptrargsafemulti1.c %s
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %S/unsafefptrargsafemulti2.c %s --
-// RUN: 3c -base-dir=%t.checked -alltypes -output-dir=%t.convert_again %t.checked/unsafefptrargsafemulti1.c %t.checked/unsafefptrargsafemulti2.c --
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %S/unsafefptrargsafemulti2.c %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%t.checked -alltypes -output-dir=%t.convert_again %t.checked/unsafefptrargsafemulti1.c %t.checked/unsafefptrargsafemulti2.c -- -Wno-error=incompatible-function-pointer-types
 // RUN: test ! -f %t.convert_again/unsafefptrargsafemulti1.c
 // RUN: test ! -f %t.convert_again/unsafefptrargsafemulti2.c
 

--- a/clang/test/3C/generated_tests/unsafefptrargsafemulti2.c
+++ b/clang/test/3C/generated_tests/unsafefptrargsafemulti2.c
@@ -1,11 +1,11 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -addcr -alltypes -output-dir=%t.checkedALL2 %S/unsafefptrargsafemulti1.c %s --
-// RUN: 3c -base-dir=%S -addcr -output-dir=%t.checkedNOALL2 %S/unsafefptrargsafemulti1.c %s --
-// RUN: %clang -working-directory=%t.checkedNOALL2 -c unsafefptrargsafemulti1.c unsafefptrargsafemulti2.c
+// RUN: 3c -base-dir=%S -addcr -alltypes -output-dir=%t.checkedALL2 %S/unsafefptrargsafemulti1.c %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%S -addcr -output-dir=%t.checkedNOALL2 %S/unsafefptrargsafemulti1.c %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: %clang -working-directory=%t.checkedNOALL2 -c -Wno-error=incompatible-function-pointer-types unsafefptrargsafemulti1.c unsafefptrargsafemulti2.c
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" --input-file %t.checkedNOALL2/unsafefptrargsafemulti2.c %s
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" --input-file %t.checkedALL2/unsafefptrargsafemulti2.c %s
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %S/unsafefptrargsafemulti1.c %s --
-// RUN: 3c -base-dir=%t.checked -alltypes -output-dir=%t.convert_again %t.checked/unsafefptrargsafemulti1.c %t.checked/unsafefptrargsafemulti2.c --
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %S/unsafefptrargsafemulti1.c %s -- -Wno-error=incompatible-function-pointer-types
+// RUN: 3c -base-dir=%t.checked -alltypes -output-dir=%t.convert_again %t.checked/unsafefptrargsafemulti1.c %t.checked/unsafefptrargsafemulti2.c -- -Wno-error=incompatible-function-pointer-types
 // RUN: test ! -f %t.convert_again/unsafefptrargsafemulti1.c
 // RUN: test ! -f %t.convert_again/unsafefptrargsafemulti2.c
 

--- a/clang/test/3C/inline_anon_structs_cross_tu.c
+++ b/clang/test/3C/inline_anon_structs_cross_tu.c
@@ -32,20 +32,20 @@
 //
 // RUN: 3c -base-dir=%S -addcr -alltypes -output-dir=%t.checkedALL_AB %S/inline_anon_structs.c %s --
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK","CHECK_AB" --input-file %t.checkedALL_AB/inline_anon_structs.c %S/inline_anon_structs.c
-// RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK","CHECK_AB" --input-file %t.checkedALL_AB/inline_anon_structs_cross_tu.c %s
+// RUN: FileCheck -match-full-lines -check-prefixes="CHECK_AB" --input-file %t.checkedALL_AB/inline_anon_structs_cross_tu.c %s
 // RUN: 3c -base-dir=%S -addcr -output-dir=%t.checkedNOALL_AB %S/inline_anon_structs.c %s --
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK","CHECK_AB" --input-file %t.checkedNOALL_AB/inline_anon_structs.c %S/inline_anon_structs.c
-// RUN: FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK","CHECK_AB" --input-file %t.checkedNOALL_AB/inline_anon_structs_cross_tu.c %s
+// RUN: FileCheck -match-full-lines -check-prefixes="CHECK_AB" --input-file %t.checkedNOALL_AB/inline_anon_structs_cross_tu.c %s
 
 // Tests of the "inline_anon_structs_cross_tu.c, inline_anon_structs.c" order
 // (called "BA").
 //
 // RUN: 3c -base-dir=%S -addcr -alltypes -output-dir=%t.checkedALL_BA  %s %S/inline_anon_structs.c --
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK","CHECK_BA" --input-file %t.checkedALL_BA/inline_anon_structs.c %S/inline_anon_structs.c
-// RUN: FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK","CHECK_BA" --input-file %t.checkedALL_BA/inline_anon_structs_cross_tu.c %s
+// RUN: FileCheck -match-full-lines -check-prefixes="CHECK_BA" --input-file %t.checkedALL_BA/inline_anon_structs_cross_tu.c %s
 // RUN: 3c -base-dir=%S -addcr -output-dir=%t.checkedNOALL_BA %s %S/inline_anon_structs.c --
 // RUN: FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK","CHECK_BA" --input-file %t.checkedNOALL_BA/inline_anon_structs.c %S/inline_anon_structs.c
-// RUN: FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK","CHECK_BA" --input-file %t.checkedNOALL_BA/inline_anon_structs_cross_tu.c %s
+// RUN: FileCheck -match-full-lines -check-prefixes="CHECK_BA" --input-file %t.checkedNOALL_BA/inline_anon_structs_cross_tu.c %s
 
 void second_tu_fn(void) {
   // In the AB order, the global `cross_tu_numbering_test` variable in

--- a/clang/test/3C/itype_nt_arr_cast.c
+++ b/clang/test/3C/itype_nt_arr_cast.c
@@ -1,8 +1,8 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
-// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/itype_nt_arr_cast.c -- | diff %t.checked/itype_nt_arr_cast.c -
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s -- -Wno-error=int-conversion
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/itype_nt_arr_cast.c -- -Wno-error=int-conversion | diff %t.checked/itype_nt_arr_cast.c -
 
 char *fn1() {
 //CHECK_ALL: char *fn1(void) : itype(_Nt_array_ptr<char>) {

--- a/clang/test/3C/itype_typedef.c
+++ b/clang/test/3C/itype_typedef.c
@@ -1,9 +1,9 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
-// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/itype_typedef.c -- | diff %t.checked/itype_typedef.c -
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=int-conversion | %clang -c -Wno-error=int-conversion -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s -- -Wno-error=int-conversion
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/itype_typedef.c -- -Wno-error=int-conversion | diff %t.checked/itype_typedef.c -
 
 // Itype typedef on the paramter
 

--- a/clang/test/3C/itype_undef.c
+++ b/clang/test/3C/itype_undef.c
@@ -1,9 +1,9 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S --infer-types-for-undefs -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
-// RUN: 3c -base-dir=%S --infer-types-for-undefs -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
-// RUN: 3c -base-dir=%S --infer-types-for-undefs -alltypes -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
-// RUN: 3c -base-dir=%S --infer-types-for-undefs -alltypes -output-dir=%t.checked %s --
-// RUN: 3c -base-dir=%t.checked --infer-types-for-undefs -alltypes %t.checked/itype_undef.c -- | diff %t.checked/itype_undef.c -
+// RUN: 3c -base-dir=%S --infer-types-for-undefs -alltypes -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S --infer-types-for-undefs -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S --infer-types-for-undefs -alltypes -addcr %s -- -Wno-error=int-conversion | %clang -c -Wno-error=int-conversion -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S --infer-types-for-undefs -alltypes -output-dir=%t.checked %s -- -Wno-error=int-conversion
+// RUN: 3c -base-dir=%t.checked --infer-types-for-undefs -alltypes %t.checked/itype_undef.c -- -Wno-error=int-conversion | diff %t.checked/itype_undef.c -
 
 // Basic checks for adding itypes on undefined functions.
 void test0(int *a);

--- a/clang/test/3C/itypecast.c
+++ b/clang/test/3C/itypecast.c
@@ -3,11 +3,11 @@
 // Checks cast insertion while passing arguments to itype parameters.
 //
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -addcr -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
-// RUN: 3c -base-dir=%S -output-dir=%t.checked %s --
-// RUN: 3c -base-dir=%t.checked %t.checked/itypecast.c -- | diff -w %t.checked/itypecast.c -
+// RUN: 3c -base-dir=%S -addcr -alltypes %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=int-conversion | %clang -c -Wno-error=int-conversion -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -output-dir=%t.checked %s -- -Wno-error=int-conversion
+// RUN: 3c -base-dir=%t.checked %t.checked/itypecast.c -- -Wno-error=int-conversion | diff -w %t.checked/itypecast.c -
 
 int foo(int **p : itype(_Ptr<_Ptr<int>>));
 int bar(int **p : itype(_Ptr<int *>));

--- a/clang/test/3C/itypes_for_extern.c
+++ b/clang/test/3C/itypes_for_extern.c
@@ -1,9 +1,9 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -itypes-for-extern -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
-// RUN: 3c -base-dir=%S -itypes-for-extern -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
-// RUN: 3c -base-dir=%S -itypes-for-extern -alltypes -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
-// RUN: 3c -base-dir=%S -itypes-for-extern -alltypes -output-dir=%t.checked %s --
-// RUN: 3c -base-dir=%t.checked -itypes-for-extern -alltypes %t.checked/itypes_for_extern.c -- | diff %t.checked/itypes_for_extern.c -
+// RUN: 3c -base-dir=%S -itypes-for-extern -alltypes -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S -itypes-for-extern -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S -itypes-for-extern -alltypes -addcr %s -- -Wno-error=int-conversion | %clang -c -Wno-error=int-conversion -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -itypes-for-extern -alltypes -output-dir=%t.checked %s -- -Wno-error=int-conversion
+// RUN: 3c -base-dir=%t.checked -itypes-for-extern -alltypes %t.checked/itypes_for_extern.c -- -Wno-error=int-conversion | diff %t.checked/itypes_for_extern.c -
 
 // Simplest test case: a would normally get a checked type, but is given an
 // itype because of the flag.

--- a/clang/test/3C/k_and_r.c
+++ b/clang/test/3C/k_and_r.c
@@ -1,9 +1,9 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
-// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/k_and_r.c -- | diff %t.checked/k_and_r.c -
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=int-conversion | %clang -c -Wno-error=int-conversion -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s -- -Wno-error=int-conversion
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/k_and_r.c -- -Wno-error=int-conversion | diff %t.checked/k_and_r.c -
 
 // clang-format doesn't seem to understand K&R function declarations and makes a
 // mess.

--- a/clang/test/3C/liberal_itypes_fp.c
+++ b/clang/test/3C/liberal_itypes_fp.c
@@ -1,9 +1,9 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK" %s
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
-// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/liberal_itypes_fp.c -- | diff %t.checked/liberal_itypes_fp.c -
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -Wno-error=int-conversion -Wno-error=implicit-function-declaration | FileCheck -match-full-lines -check-prefixes="CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=int-conversion -Wno-error=implicit-function-declaration | FileCheck -match-full-lines -check-prefixes="CHECK" %s
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -Wno-error=int-conversion -Wno-error=implicit-function-declaration | %clang -c -Wno-error=int-conversion -Wno-error=implicit-function-declaration -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s -- -Wno-error=int-conversion -Wno-error=implicit-function-declaration
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/liberal_itypes_fp.c -- -Wno-error=int-conversion -Wno-error=implicit-function-declaration | diff %t.checked/liberal_itypes_fp.c -
 
 void fp_test0(int *i) { i = 0; }
 // CHECK: void fp_test0(int *i : itype(_Ptr<int>)) { i = 0; }

--- a/clang/test/3C/liberal_itypes_ptr.c
+++ b/clang/test/3C/liberal_itypes_ptr.c
@@ -1,9 +1,9 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
-// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/liberal_itypes_ptr.c -- | diff %t.checked/liberal_itypes_ptr.c -
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=int-conversion | %clang -c -Wno-error=int-conversion -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s -- -Wno-error=int-conversion
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/liberal_itypes_ptr.c -- -Wno-error=int-conversion | diff %t.checked/liberal_itypes_ptr.c -
 
 void foo(int *a) {}
 // CHECK: void foo(_Ptr<int> a) _Checked {}

--- a/clang/test/3C/liberal_itypes_ptrptr.c
+++ b/clang/test/3C/liberal_itypes_ptrptr.c
@@ -1,9 +1,9 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK" %s
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
-// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/liberal_itypes_ptrptr.c -- | diff %t.checked/liberal_itypes_ptrptr.c -
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK" %s
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -Wno-error=int-conversion | %clang -c -Wno-error=int-conversion -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s -- -Wno-error=int-conversion
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/liberal_itypes_ptrptr.c -- -Wno-error=int-conversion | diff %t.checked/liberal_itypes_ptrptr.c -
 
 void ptrptr(int **g) {}
 //CHECK: void ptrptr(_Ptr<int *> g) {}

--- a/clang/test/3C/macroConcat.c
+++ b/clang/test/3C/macroConcat.c
@@ -1,9 +1,9 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -addcr -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
-// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/macroConcat.c -- | diff %t.checked/macroConcat.c -
+// RUN: 3c -base-dir=%S -addcr -alltypes %s -- -Wno-error=implicit-int | FileCheck -match-full-lines -check-prefixes="CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=implicit-int | FileCheck -match-full-lines -check-prefixes="CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=implicit-int | %clang -c -Wno-error=implicit-int -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s -- -Wno-error=implicit-int
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/macroConcat.c -- -Wno-error=implicit-int | diff %t.checked/macroConcat.c -
 
 // I suspect the original source locations might have been an important aspect
 // of this test, so we shouldn't let clang-format change them. ~ Matt 2021-03-10

--- a/clang/test/3C/macro_itype.c
+++ b/clang/test/3C/macro_itype.c
@@ -1,9 +1,9 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK" %s
-// RUN: 3c -base-dir=%S -alltypes -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
-// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/macro_itype.c -- | diff %t.checked/macro_itype.c -
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK" %s
+// RUN: 3c -base-dir=%S -alltypes -addcr %s -- -Wno-error=int-conversion | %clang -c -Wno-error=int-conversion -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s -- -Wno-error=int-conversion
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/macro_itype.c -- -Wno-error=int-conversion | diff %t.checked/macro_itype.c -
 
 // Example encountered while converting libjpeg. This triggered an assertion
 // fail because the ItypeStr extracted from the source was empty.

--- a/clang/test/3C/mergebodies1.c
+++ b/clang/test/3C/mergebodies1.c
@@ -1,8 +1,8 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -addcr -output-dir=%t.checked %s %S/mergebodies2.c --
-// RUN: %clang -working-directory=%t.checked -c mergebodies1.c mergebodies2.c
+// RUN: 3c -base-dir=%S -addcr -output-dir=%t.checked %s %S/mergebodies2.c -- -Wno-error=int-conversion
+// RUN: %clang -working-directory=%t.checked -c mergebodies1.c mergebodies2.c -Wno-error=int-conversion
 // RUN: FileCheck -match-full-lines --input-file %t.checked/mergebodies1.c %s
-// RUN: 3c -base-dir=%t.checked -output-dir=%t.convert_again %t.checked/mergebodies1.c %t.checked/mergebodies2.c --
+// RUN: 3c -base-dir=%t.checked -output-dir=%t.convert_again %t.checked/mergebodies1.c %t.checked/mergebodies2.c -- -Wno-error=int-conversion
 // RUN: test ! -f %t.convert_again/mergebodies1.c
 
 // This test and its counterpart check for merging functions with bodies,
@@ -35,13 +35,13 @@ int *fnPtrParamUnsafe(int (*)(int,int), int(*)(int*));
 int *fnPtrParamSafe(int (*)(int,int));
 // CHECK: int *fnPtrParamSafe(_Ptr<int (int, int)> fn) : itype(_Ptr<int>);
 
-void main(int a, char **b);
-// CHECK: void main(int a, _Ptr<_Ptr<char>> b);
-
 void main() {
 // CHECK: void main(int a, _Ptr<_Ptr<char>> b) {
   int f = safeBody(1,(int *)2);
 }
+
+void main(int a, char **b);
+// CHECK: void main(int a, _Ptr<_Ptr<char>> b);
 
 int *noParams() {
   return 0;

--- a/clang/test/3C/mergebodies2.c
+++ b/clang/test/3C/mergebodies2.c
@@ -1,8 +1,8 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -addcr -output-dir=%t.checked %s %S/mergebodies1.c --
-// RUN: %clang -working-directory=%t.checked -c mergebodies2.c mergebodies1.c
+// RUN: 3c -base-dir=%S -addcr -output-dir=%t.checked %s %S/mergebodies1.c -- -Wno-error=int-conversion
+// RUN: %clang -working-directory=%t.checked -c mergebodies2.c mergebodies1.c -Wno-error=int-conversion
 // RUN: FileCheck -match-full-lines --input-file %t.checked/mergebodies2.c %s
-// RUN: 3c -base-dir=%t.checked -output-dir=%t.convert_again %t.checked/mergebodies2.c %t.checked/mergebodies1.c --
+// RUN: 3c -base-dir=%t.checked -output-dir=%t.convert_again %t.checked/mergebodies2.c %t.checked/mergebodies1.c -- -Wno-error=int-conversion
 // RUN: test ! -f %t.convert_again/mergebodies2.c
 
 // This test and its counterpart check for merging functions with bodies,

--- a/clang/test/3C/multivardecls.c
+++ b/clang/test/3C/multivardecls.c
@@ -1,9 +1,9 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -addcr -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
-// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/multivardecls.c -- | diff %t.checked/multivardecls.c -
+// RUN: 3c -base-dir=%S -addcr -alltypes %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=int-conversion | %clang -c -Wno-error=int-conversion -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s -- -Wno-error=int-conversion
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/multivardecls.c -- -Wno-error=int-conversion | diff %t.checked/multivardecls.c -
 
 #include <stddef.h>
 #include <stdlib.h>

--- a/clang/test/3C/multivardecls_complex_types.c
+++ b/clang/test/3C/multivardecls_complex_types.c
@@ -6,17 +6,17 @@
 
 // RUN: rm -rf %t*
 
-// RUN: 3c -base-dir=%S -addcr -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
-// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/multivardecls_complex_types.c -- | diff %t.checked/multivardecls_complex_types.c -
+// RUN: 3c -base-dir=%S -addcr -alltypes %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=int-conversion | %clang -c -Wno-error=int-conversion -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s -- -Wno-error=int-conversion
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/multivardecls_complex_types.c -- -Wno-error=int-conversion | diff %t.checked/multivardecls_complex_types.c -
 
-// RUN: 3c -base-dir=%S -itypes-for-extern -alltypes -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ITE_ALL","CHECK_ITE" %s
-// RUN: 3c -base-dir=%S -itypes-for-extern -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ITE_NOALL","CHECK_ITE" %s
-// RUN: 3c -base-dir=%S -itypes-for-extern -alltypes -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
-// RUN: 3c -base-dir=%S -itypes-for-extern -alltypes -output-dir=%t.checked_ITE %s --
-// RUN: 3c -base-dir=%t.checked_ITE -itypes-for-extern -alltypes %t.checked_ITE/multivardecls_complex_types.c -- | diff %t.checked_ITE/multivardecls_complex_types.c -
+// RUN: 3c -base-dir=%S -itypes-for-extern -alltypes -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK_ITE_ALL","CHECK_ITE" %s
+// RUN: 3c -base-dir=%S -itypes-for-extern -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK_ITE_NOALL","CHECK_ITE" %s
+// RUN: 3c -base-dir=%S -itypes-for-extern -alltypes -addcr %s -- -Wno-error=int-conversion | %clang -c -Wno-error=int-conversion -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -itypes-for-extern -alltypes -output-dir=%t.checked_ITE %s -- -Wno-error=int-conversion
+// RUN: 3c -base-dir=%t.checked_ITE -itypes-for-extern -alltypes %t.checked_ITE/multivardecls_complex_types.c -- -Wno-error=int-conversion | diff %t.checked_ITE/multivardecls_complex_types.c -
 
 // A multi-decl with a mix of pointers and arrays, including an "unchecked
 // pointer to constant size array" member that would trigger a known bug in

--- a/clang/test/3C/noproto.c
+++ b/clang/test/3C/noproto.c
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines --check-prefixes="CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -fcheckedc-extension -x c -o %t.unused -
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=implicit-function-declaration | FileCheck -match-full-lines --check-prefixes="CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=implicit-function-declaration | %clang -c -Wno-error=implicit-function-declaration -fcheckedc-extension -x c -o %t.unused -
 
 int foo(int x) {
   //CHECK: int foo(int x) {

--- a/clang/test/3C/partial_checked.c
+++ b/clang/test/3C/partial_checked.c
@@ -1,9 +1,9 @@
 // RUN: rm -rf %t*
-// RUN: 3c -base-dir=%S -addcr -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
-// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s --
-// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/partial_checked.c -- | diff %t.checked/partial_checked.c -
+// RUN: 3c -base-dir=%S -addcr -alltypes %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -Wno-error=int-conversion | %clang -c -Wno-error=int-conversion -fcheckedc-extension -x c -o /dev/null -
+// RUN: 3c -base-dir=%S -alltypes -output-dir=%t.checked %s -- -Wno-error=int-conversion
+// RUN: 3c -base-dir=%t.checked -alltypes %t.checked/partial_checked.c -- -Wno-error=int-conversion | diff %t.checked/partial_checked.c -
 
 void test0(_Ptr<int *> a) {}
 // CHECK: void test0(_Ptr<_Ptr<int>> a) _Checked {}

--- a/clang/test/3C/type_params.c
+++ b/clang/test/3C/type_params.c
@@ -1,9 +1,9 @@
 // RUN: rm -rf %t*
 // Manually passing fortify source to avoid issues surrounding the way compiler
 // builtins are handled. (See issue #630)
-// RUN: 3c -base-dir=%S -addcr -alltypes %s -- -D_FORTIFY_SOURCE=0 | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- -D_FORTIFY_SOURCE=0 | FileCheck -match-full-lines -check-prefixes="CHECK" %s
-// RUN: 3c -base-dir=%S -addcr %s -- -D_FORTIFY_SOURCE=0 | %clang -c -fcheckedc-extension -x c -o %t1.unused -
+// RUN: 3c -base-dir=%S -addcr -alltypes %s -- -D_FORTIFY_SOURCE=0 -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -D_FORTIFY_SOURCE=0 -Wno-error=int-conversion | FileCheck -match-full-lines -check-prefixes="CHECK" %s
+// RUN: 3c -base-dir=%S -addcr %s -- -D_FORTIFY_SOURCE=0 -Wno-error=int-conversion | %clang -c -Wno-error=int-conversion -fcheckedc-extension -x c -o %t1.unused -
 
 // General demonstration
 _Itype_for_any(T) void *test_single(void *a


### PR DESCRIPTION
The following changes were made:

- Fixed an issue where the `-f3c-tool` option was not enabled in clang even when passing it as a command line option.
- Fixed an issue with typedef discovery which was caused due to the new `ElaboratedType` that surrounds `TypedefType`.
- Removed all unused check prefixes from 3C tests.
- Added compiler flags to 3C tests to convert clang errors to warnings. These errors were warnings in the previous version of clang.